### PR TITLE
test(boavizt): add tests for client and api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,12 @@
             <version>4.12.0</version>
         </dependency>
         <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>4.12.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
             <version>3.2.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -125,5 +125,17 @@
             <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.8.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.8.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>5.13.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <version>${testcontainers.version}</version>

--- a/src/main/java/com/digitalpebble/spruce/modules/boavizta/BoaviztAPIClient.java
+++ b/src/main/java/com/digitalpebble/spruce/modules/boavizta/BoaviztAPIClient.java
@@ -5,6 +5,8 @@ package com.digitalpebble.spruce.modules.boavizta;
 import com.digitalpebble.spruce.Provider;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jspecify.annotations.NonNull;
+
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -23,11 +25,20 @@ public class BoaviztAPIClient {
 
     private final String host;
 
-    public BoaviztAPIClient(String host) {
+    public BoaviztAPIClient(@NonNull String host) {
+        if (host == null || host.trim().isEmpty()) {
+            throw new IllegalArgumentException("Host cannot be null, empty, or whitespace only");
+        }
         this.host = host;
     }
 
-    public double[] getEnergyEstimates(Provider p, String instanceType) throws IOException, NullPointerException {
+    public double[] getEnergyEstimates(@NonNull Provider p, @NonNull String instanceType) throws IOException {
+        if (p == null) {
+            throw new IllegalArgumentException("Provider cannot be null");
+        }
+        if (instanceType == null || instanceType.trim().isEmpty()) {
+            throw new IllegalArgumentException("Instance type cannot be null, empty, or whitespace only");
+        }
 
         final String url = String.format(URLPattern, host, instanceType);
 

--- a/src/test/java/com/digitalpebble/spruce/modules/boavizta/AbstractBoaviztaTestExample.java
+++ b/src/test/java/com/digitalpebble/spruce/modules/boavizta/AbstractBoaviztaTestExample.java
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalpebble.spruce.modules.boavizta;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Example test class demonstrating how to use the refactored AbstractBoaviztaTest
+ * with a static container that starts once for all tests.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class AbstractBoaviztaTestExample extends AbstractBoaviztaTest {
+
+    @Test
+    void testContainerIsRunning() {
+        // Verify the container is accessible
+        assertNotNull(getContainer());
+        assertTrue(getContainer().isRunning());
+        
+        // Get container details
+        String host = getContainerHost();
+        int port = getContainerPort();
+        String url = getContainerUrl();
+        
+        System.out.println("Container running at: " + url);
+        System.out.println("Host: " + host + ", Port: " + port);
+    }
+
+    @Test
+    void testContainerReuse() {
+        // This test should use the same container instance
+        assertNotNull(getContainer());
+        assertTrue(getContainer().isRunning());
+        
+        // Both tests should see the same container
+        System.out.println("Container ID: " + getContainer().getContainerId());
+    }
+}

--- a/src/test/java/com/digitalpebble/spruce/modules/boavizta/BoaviztAPIClientTest.java
+++ b/src/test/java/com/digitalpebble/spruce/modules/boavizta/BoaviztAPIClientTest.java
@@ -1,0 +1,373 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalpebble.spruce.modules.boavizta;
+
+import com.digitalpebble.spruce.Provider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BoaviztAPIClientTest extends AbstractBoaviztaTest {
+
+    private BoaviztAPIClient client;
+    private static final String TEST_HOST = "http://localhost:5000";
+
+    @BeforeEach
+    void setUp() {
+        client = new BoaviztAPIClient(TEST_HOST);
+    }
+
+    @Test
+    void testConstructor() {
+        BoaviztAPIClient testClient = new BoaviztAPIClient("http://custom-host:8080");
+        assertNotNull(testClient);
+    }
+
+    @Test
+    void testConstructorWithNullHost() {
+        // The constructor doesn't actually throw NullPointerException for null host
+        // It just stores the null value, which will cause issues later when making HTTP calls
+        BoaviztAPIClient testClient = new BoaviztAPIClient(null);
+        assertNotNull(testClient);
+    }
+
+    @Test
+    void testConstructorWithEmptyHost() {
+        BoaviztAPIClient testClient = new BoaviztAPIClient("");
+        assertNotNull(testClient);
+    }
+
+    @Test
+    void testConstructorWithHttpsHost() {
+        BoaviztAPIClient testClient = new BoaviztAPIClient("https://secure-host:8443");
+        assertNotNull(testClient);
+    }
+
+    @Test
+    void testGetEnergyEstimatesWithValidInstanceType() throws IOException {
+        // This test will attempt to call the actual API
+        // It may succeed if the test container is running, or fail gracefully if not
+        try {
+            double[] result = client.getEnergyEstimates(Provider.AWS, "t3.micro");
+            assertNotNull(result);
+            assertEquals(2, result.length);
+            assertTrue(result[0] >= 0, "Use energy should be non-negative");
+            assertTrue(result[1] >= 0, "Embedded energy should be non-negative");
+        } catch (IOException e) {
+            // Expected if the test container is not accessible
+            assertTrue(e.getMessage().contains("Unexpected code") || 
+                      e.getMessage().contains("Connection refused") ||
+                      e.getMessage().contains("Failed to connect"),
+                      "Expected connection-related error, got: " + e.getMessage());
+        }
+    }
+
+    @Test
+    void testGetEnergyEstimatesWithDifferentInstanceTypes() throws IOException {
+        String[] instanceTypes = {"t3.micro", "t3.small", "t3.medium", "c5.large", "m5.xlarge"};
+        
+        for (String instanceType : instanceTypes) {
+            try {
+                double[] result = client.getEnergyEstimates(Provider.AWS, instanceType);
+                assertNotNull(result);
+                assertEquals(2, result.length);
+                assertTrue(result[0] >= 0, "Use energy should be non-negative for " + instanceType);
+                assertTrue(result[1] >= 0, "Embedded energy should be non-negative for " + instanceType);
+            } catch (IOException e) {
+                // Expected if the test container is not accessible
+                assertTrue(e.getMessage().contains("Unexpected code") || 
+                          e.getMessage().contains("Connection refused") ||
+                          e.getMessage().contains("Failed to connect"),
+                          "Expected connection-related error for " + instanceType + ", got: " + e.getMessage());
+            }
+        }
+    }
+
+    @Test
+    void testGetEnergyEstimatesWithNullInstanceType() throws IOException {
+        // The method doesn't throw NullPointerException for null instance type
+        // It just passes "null" as a string to the API
+        try {
+            double[] result = client.getEnergyEstimates(Provider.AWS, null);
+            assertNotNull(result);
+            assertEquals(2, result.length);
+        } catch (IOException e) {
+            // Expected if the test container is not accessible
+            assertTrue(e.getMessage().contains("Unexpected code") || 
+                      e.getMessage().contains("Connection refused") ||
+                      e.getMessage().contains("Failed to connect"),
+                      "Expected connection-related error, got: " + e.getMessage());
+        }
+    }
+
+    @Test
+    void testGetEnergyEstimatesWithEmptyInstanceType() throws IOException {
+        try {
+            double[] result = client.getEnergyEstimates(Provider.AWS, "");
+            assertNotNull(result);
+            assertEquals(2, result.length);
+        } catch (IOException e) {
+            // Expected if the test container is not accessible
+            assertTrue(e.getMessage().contains("Unexpected code") || 
+                      e.getMessage().contains("Connection refused") ||
+                      e.getMessage().contains("Failed to connect"),
+                      "Expected connection-related error, got: " + e.getMessage());
+        }
+    }
+
+    @Test
+    void testGetEnergyEstimatesWithWhitespaceInstanceType() throws IOException {
+        try {
+            double[] result = client.getEnergyEstimates(Provider.AWS, "   ");
+            assertNotNull(result);
+            assertEquals(2, result.length);
+        } catch (IOException e) {
+            // Expected if the test container is not accessible
+            assertTrue(e.getMessage().contains("Unexpected code") || 
+                      e.getMessage().contains("Connection refused") ||
+                      e.getMessage().contains("Failed to connect"),
+                      "Expected connection-related error, got: " + e.getMessage());
+        }
+    }
+
+    @Test
+    void testGetEnergyEstimatesWithSpecialCharacters() throws IOException {
+        String[] specialInstanceTypes = {"t3.micro@test", "t3.micro-test", "t3.micro_test", "t3.micro+test"};
+        
+        for (String instanceType : specialInstanceTypes) {
+            try {
+                double[] result = client.getEnergyEstimates(Provider.AWS, instanceType);
+                assertNotNull(result);
+                assertEquals(2, result.length);
+            } catch (IOException e) {
+                // Expected if the test container is not accessible
+                assertTrue(e.getMessage().contains("Unexpected code") || 
+                          e.getMessage().contains("Connection refused") ||
+                          e.getMessage().contains("Failed to connect"),
+                          "Expected connection-related error for " + instanceType + ", got: " + e.getMessage());
+            }
+        }
+    }
+
+    @Test
+    void testGetEnergyEstimatesWithVeryLongInstanceType() throws IOException {
+        String longInstanceType = "t3.micro".repeat(100); // Create a very long instance type
+        
+        try {
+            double[] result = client.getEnergyEstimates(Provider.AWS, longInstanceType);
+            assertNotNull(result);
+            assertEquals(2, result.length);
+        } catch (IOException e) {
+            // Expected if the test container is not accessible
+            assertTrue(e.getMessage().contains("Unexpected code") || 
+                      e.getMessage().contains("Connection refused") ||
+                      e.getMessage().contains("Failed to connect"),
+                      "Expected connection-related error, got: " + e.getMessage());
+        }
+    }
+
+    @Test
+    void testGetEnergyEstimatesWithDifferentProviders() throws IOException {
+        // Test with different provider values (though the API might only support AWS)
+        Provider[] providers = {Provider.AWS, Provider.AZURE, Provider.GOOGLE};
+        
+        for (Provider provider : providers) {
+            try {
+                double[] result = client.getEnergyEstimates(provider, "t3.micro");
+                assertNotNull(result);
+                assertEquals(2, result.length);
+            } catch (IOException e) {
+                // Expected if the test container is not accessible or provider not supported
+                assertTrue(e.getMessage().contains("Unexpected code") || 
+                          e.getMessage().contains("Connection refused") ||
+                          e.getMessage().contains("Failed to connect"),
+                          "Expected connection-related error for " + provider + ", got: " + e.getMessage());
+            }
+        }
+    }
+
+    @Test
+    void testGetEnergyEstimatesWithComplexInstanceTypes() throws IOException {
+        String[] complexInstanceTypes = {
+            "db.r5.24xlarge", 
+            "c5.18xlarge.search", 
+            "m5.12xlarge",
+            "db.t3.micro",
+            "t3.micro.search"
+        };
+        
+        for (String instanceType : complexInstanceTypes) {
+            try {
+                double[] result = client.getEnergyEstimates(Provider.AWS, instanceType);
+                assertNotNull(result);
+                assertEquals(2, result.length);
+                assertTrue(result[0] >= 0, "Use energy should be non-negative for " + instanceType);
+                assertTrue(result[1] >= 0, "Embedded energy should be non-negative for " + instanceType);
+            } catch (IOException e) {
+                // Expected if the test container is not accessible
+                assertTrue(e.getMessage().contains("Unexpected code") || 
+                          e.getMessage().contains("Connection refused") ||
+                          e.getMessage().contains("Failed to connect"),
+                          "Expected connection-related error for " + instanceType + ", got: " + e.getMessage());
+            }
+        }
+    }
+
+    @Test
+    void testGetEnergyEstimatesWithEdgeCaseInstanceTypes() throws IOException {
+        String[] edgeCaseInstanceTypes = {
+            "0",           // Single character
+            "a",           // Single letter
+            "instance",    // Generic name
+            "test",        // Test name
+            "123456789",   // Numbers only
+            "a1b2c3d4e5"  // Mixed alphanumeric
+        };
+        
+        for (String instanceType : edgeCaseInstanceTypes) {
+            try {
+                double[] result = client.getEnergyEstimates(Provider.AWS, instanceType);
+                assertNotNull(result);
+                assertEquals(2, result.length);
+            } catch (IOException e) {
+                // Expected if the test container is not accessible
+                assertTrue(e.getMessage().contains("Unexpected code") || 
+                          e.getMessage().contains("Connection refused") ||
+                          e.getMessage().contains("Failed to connect"),
+                          "Expected connection-related error for " + instanceType + ", got: " + e.getMessage());
+            }
+        }
+    }
+
+    @Test
+    void testGetEnergyEstimatesWithNullProvider() throws IOException {
+        // The method doesn't throw NullPointerException for null provider
+        // It just passes null to the API call
+        try {
+            double[] result = client.getEnergyEstimates(null, "t3.micro");
+            assertNotNull(result);
+            assertEquals(2, result.length);
+        } catch (IOException e) {
+            // Expected if the test container is not accessible
+            assertTrue(e.getMessage().contains("Unexpected code") || 
+                      e.getMessage().contains("Connection refused") ||
+                      e.getMessage().contains("Failed to connect"),
+                      "Expected connection-related error, got: " + e.getMessage());
+        }
+    }
+
+    @Test
+    void testGetEnergyEstimatesWithEmptyProvider() {
+        // This test assumes Provider is an enum, so we can't pass empty string
+        // But we can test the behavior with a valid provider
+        assertDoesNotThrow(() -> {
+            try {
+                client.getEnergyEstimates(Provider.AWS, "t3.micro");
+            } catch (IOException e) {
+                // Expected if the test container is not accessible
+                assertTrue(e.getMessage().contains("Unexpected code") || 
+                          e.getMessage().contains("Connection refused") ||
+                          e.getMessage().contains("Failed to connect"),
+                          "Expected connection-related error, got: " + e.getMessage());
+            }
+        });
+    }
+
+    @Test
+    void testGetEnergyEstimatesWithInvalidHost() {
+        BoaviztAPIClient invalidClient = new BoaviztAPIClient("http://invalid-host-that-does-not-exist:9999");
+        
+        assertThrows(IOException.class, () -> {
+            invalidClient.getEnergyEstimates(Provider.AWS, "t3.micro");
+        });
+    }
+
+    @Test
+    void testGetEnergyEstimatesWithMalformedHost() {
+        BoaviztAPIClient malformedClient = new BoaviztAPIClient("not-a-valid-url");
+        
+        assertThrows(IllegalArgumentException.class, () -> {
+            malformedClient.getEnergyEstimates(Provider.AWS, "t3.micro");
+        });
+    }
+
+    @Test
+    void testGetEnergyEstimatesWithHttpsHost() throws IOException {
+        BoaviztAPIClient httpsClient = new BoaviztAPIClient("https://localhost:5000");
+        
+        try {
+            double[] result = httpsClient.getEnergyEstimates(Provider.AWS, "t3.micro");
+            assertNotNull(result);
+            assertEquals(2, result.length);
+        } catch (IOException e) {
+            // Expected if the test container is not accessible or HTTPS not supported
+            assertTrue(e.getMessage().contains("Unexpected code") || 
+                      e.getMessage().contains("Connection refused") ||
+                      e.getMessage().contains("Failed to connect") ||
+                      e.getMessage().contains("SSL") ||
+                      e.getMessage().contains("TLS") ||
+                      e.getMessage().contains("Read timed out"),
+                      "Expected connection-related error, got: " + e.getMessage());
+        }
+    }
+
+    @Test
+    void testGetEnergyEstimatesWithCustomPort() throws IOException {
+        BoaviztAPIClient customPortClient = new BoaviztAPIClient("http://localhost:8080");
+        
+        try {
+            double[] result = customPortClient.getEnergyEstimates(Provider.AWS, "t3.micro");
+            assertNotNull(result);
+            assertEquals(2, result.length);
+        } catch (IOException e) {
+            // Expected if the test container is not accessible on custom port
+            assertTrue(e.getMessage().contains("Unexpected code") || 
+                      e.getMessage().contains("Connection refused") ||
+                      e.getMessage().contains("Failed to connect"),
+                      "Expected connection-related error, got: " + e.getMessage());
+        }
+    }
+
+    @Test
+    void testGetEnergyEstimatesWithInstanceTypeContainingSpaces() throws IOException {
+        try {
+            double[] result = client.getEnergyEstimates(Provider.AWS, "t3 micro");
+            assertNotNull(result);
+            assertEquals(2, result.length);
+        } catch (IOException e) {
+            // Expected if the test container is not accessible
+            assertTrue(e.getMessage().contains("Unexpected code") || 
+                      e.getMessage().contains("Connection refused") ||
+                      e.getMessage().contains("Failed to connect"),
+                      "Expected connection-related error, got: " + e.getMessage());
+        }
+    }
+
+    @Test
+    void testGetEnergyEstimatesWithInstanceTypeContainingUnicode() throws IOException {
+        String[] unicodeInstanceTypes = {
+            "t3.micro-é", 
+            "t3.micro-ñ", 
+            "t3.micro-ü",
+            "t3.micro-中文",
+            "t3.micro-日本語"
+        };
+        
+        for (String instanceType : unicodeInstanceTypes) {
+            try {
+                double[] result = client.getEnergyEstimates(Provider.AWS, instanceType);
+                assertNotNull(result);
+                assertEquals(2, result.length);
+            } catch (IOException e) {
+                // Expected if the test container is not accessible
+                assertTrue(e.getMessage().contains("Unexpected code") || 
+                          e.getMessage().contains("Connection refused") ||
+                          e.getMessage().contains("Failed to connect"),
+                          "Expected connection-related error for " + instanceType + ", got: " + e.getMessage());
+            }
+        }
+    }
+}

--- a/src/test/java/com/digitalpebble/spruce/modules/boavizta/BoaviztAPIClientTest.java
+++ b/src/test/java/com/digitalpebble/spruce/modules/boavizta/BoaviztAPIClientTest.java
@@ -28,41 +28,23 @@ public class BoaviztAPIClientTest extends AbstractBoaviztaTest {
 
     @Test
     void testConstructorWithNullHost() {
-        // The constructor doesn't actually throw NullPointerException for null host
-        // It just stores the null value, which will cause issues later when making HTTP calls
-        BoaviztAPIClient testClient = new BoaviztAPIClient(null);
-        assertNotNull(testClient);
+        assertThrows(IllegalArgumentException.class, () -> {
+            new BoaviztAPIClient(null);
+        });
     }
 
     @Test
     void testConstructorWithEmptyHost() {
-        BoaviztAPIClient testClient = new BoaviztAPIClient("");
-        assertNotNull(testClient);
+        assertThrows(IllegalArgumentException.class, () -> {
+            new BoaviztAPIClient("");
+        });
     }
 
     @Test
-    void testConstructorWithHttpsHost() {
-        BoaviztAPIClient testClient = new BoaviztAPIClient("https://secure-host:8443");
-        assertNotNull(testClient);
-    }
-
-    @Test
-    void testGetEnergyEstimatesWithValidInstanceType() throws IOException {
-        // This test will attempt to call the actual API
-        // It may succeed if the test container is running, or fail gracefully if not
-        try {
-            double[] result = client.getEnergyEstimates(Provider.AWS, "t3.micro");
-            assertNotNull(result);
-            assertEquals(2, result.length);
-            assertTrue(result[0] >= 0, "Use energy should be non-negative");
-            assertTrue(result[1] >= 0, "Embedded energy should be non-negative");
-        } catch (IOException e) {
-            // Expected if the test container is not accessible
-            assertTrue(e.getMessage().contains("Unexpected code") || 
-                      e.getMessage().contains("Connection refused") ||
-                      e.getMessage().contains("Failed to connect"),
-                      "Expected connection-related error, got: " + e.getMessage());
-        }
+    void testConstructorWithWhitespaceHost() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new BoaviztAPIClient("   ");
+        });
     }
 
     @Test
@@ -87,91 +69,28 @@ public class BoaviztAPIClientTest extends AbstractBoaviztaTest {
     }
 
     @Test
-    void testGetEnergyEstimatesWithNullInstanceType() throws IOException {
-        // The method doesn't throw NullPointerException for null instance type
-        // It just passes "null" as a string to the API
-        try {
-            double[] result = client.getEnergyEstimates(Provider.AWS, null);
-            assertNotNull(result);
-            assertEquals(2, result.length);
-        } catch (IOException e) {
-            // Expected if the test container is not accessible
-            assertTrue(e.getMessage().contains("Unexpected code") || 
-                      e.getMessage().contains("Connection refused") ||
-                      e.getMessage().contains("Failed to connect"),
-                      "Expected connection-related error, got: " + e.getMessage());
-        }
+    void testGetEnergyEstimatesWithNullInstanceType() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            client.getEnergyEstimates(Provider.AWS, null);
+        });
     }
 
     @Test
-    void testGetEnergyEstimatesWithEmptyInstanceType() throws IOException {
-        try {
-            double[] result = client.getEnergyEstimates(Provider.AWS, "");
-            assertNotNull(result);
-            assertEquals(2, result.length);
-        } catch (IOException e) {
-            // Expected if the test container is not accessible
-            assertTrue(e.getMessage().contains("Unexpected code") || 
-                      e.getMessage().contains("Connection refused") ||
-                      e.getMessage().contains("Failed to connect"),
-                      "Expected connection-related error, got: " + e.getMessage());
-        }
+    void testGetEnergyEstimatesWithEmptyInstanceType() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            client.getEnergyEstimates(Provider.AWS, "");
+        });
     }
 
     @Test
-    void testGetEnergyEstimatesWithWhitespaceInstanceType() throws IOException {
-        try {
-            double[] result = client.getEnergyEstimates(Provider.AWS, "   ");
-            assertNotNull(result);
-            assertEquals(2, result.length);
-        } catch (IOException e) {
-            // Expected if the test container is not accessible
-            assertTrue(e.getMessage().contains("Unexpected code") || 
-                      e.getMessage().contains("Connection refused") ||
-                      e.getMessage().contains("Failed to connect"),
-                      "Expected connection-related error, got: " + e.getMessage());
-        }
-    }
-
-    @Test
-    void testGetEnergyEstimatesWithSpecialCharacters() throws IOException {
-        String[] specialInstanceTypes = {"t3.micro@test", "t3.micro-test", "t3.micro_test", "t3.micro+test"};
-        
-        for (String instanceType : specialInstanceTypes) {
-            try {
-                double[] result = client.getEnergyEstimates(Provider.AWS, instanceType);
-                assertNotNull(result);
-                assertEquals(2, result.length);
-            } catch (IOException e) {
-                // Expected if the test container is not accessible
-                assertTrue(e.getMessage().contains("Unexpected code") || 
-                          e.getMessage().contains("Connection refused") ||
-                          e.getMessage().contains("Failed to connect"),
-                          "Expected connection-related error for " + instanceType + ", got: " + e.getMessage());
-            }
-        }
-    }
-
-    @Test
-    void testGetEnergyEstimatesWithVeryLongInstanceType() throws IOException {
-        String longInstanceType = "t3.micro".repeat(100); // Create a very long instance type
-        
-        try {
-            double[] result = client.getEnergyEstimates(Provider.AWS, longInstanceType);
-            assertNotNull(result);
-            assertEquals(2, result.length);
-        } catch (IOException e) {
-            // Expected if the test container is not accessible
-            assertTrue(e.getMessage().contains("Unexpected code") || 
-                      e.getMessage().contains("Connection refused") ||
-                      e.getMessage().contains("Failed to connect"),
-                      "Expected connection-related error, got: " + e.getMessage());
-        }
+    void testGetEnergyEstimatesWithWhitespaceInstanceType() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            client.getEnergyEstimates(Provider.AWS, "   ");
+        });
     }
 
     @Test
     void testGetEnergyEstimatesWithDifferentProviders() throws IOException {
-        // Test with different provider values (though the API might only support AWS)
         Provider[] providers = {Provider.AWS, Provider.AZURE, Provider.GOOGLE};
         
         for (Provider provider : providers) {
@@ -195,8 +114,7 @@ public class BoaviztAPIClientTest extends AbstractBoaviztaTest {
             "db.r5.24xlarge", 
             "c5.18xlarge.search", 
             "m5.12xlarge",
-            "db.t3.micro",
-            "t3.micro.search"
+            "db.t3.micro"
         };
         
         for (String instanceType : complexInstanceTypes) {
@@ -217,62 +135,9 @@ public class BoaviztAPIClientTest extends AbstractBoaviztaTest {
     }
 
     @Test
-    void testGetEnergyEstimatesWithEdgeCaseInstanceTypes() throws IOException {
-        String[] edgeCaseInstanceTypes = {
-            "0",           // Single character
-            "a",           // Single letter
-            "instance",    // Generic name
-            "test",        // Test name
-            "123456789",   // Numbers only
-            "a1b2c3d4e5"  // Mixed alphanumeric
-        };
-        
-        for (String instanceType : edgeCaseInstanceTypes) {
-            try {
-                double[] result = client.getEnergyEstimates(Provider.AWS, instanceType);
-                assertNotNull(result);
-                assertEquals(2, result.length);
-            } catch (IOException e) {
-                // Expected if the test container is not accessible
-                assertTrue(e.getMessage().contains("Unexpected code") || 
-                          e.getMessage().contains("Connection refused") ||
-                          e.getMessage().contains("Failed to connect"),
-                          "Expected connection-related error for " + instanceType + ", got: " + e.getMessage());
-            }
-        }
-    }
-
-    @Test
-    void testGetEnergyEstimatesWithNullProvider() throws IOException {
-        // The method doesn't throw NullPointerException for null provider
-        // It just passes null to the API call
-        try {
-            double[] result = client.getEnergyEstimates(null, "t3.micro");
-            assertNotNull(result);
-            assertEquals(2, result.length);
-        } catch (IOException e) {
-            // Expected if the test container is not accessible
-            assertTrue(e.getMessage().contains("Unexpected code") || 
-                      e.getMessage().contains("Connection refused") ||
-                      e.getMessage().contains("Failed to connect"),
-                      "Expected connection-related error, got: " + e.getMessage());
-        }
-    }
-
-    @Test
-    void testGetEnergyEstimatesWithEmptyProvider() {
-        // This test assumes Provider is an enum, so we can't pass empty string
-        // But we can test the behavior with a valid provider
-        assertDoesNotThrow(() -> {
-            try {
-                client.getEnergyEstimates(Provider.AWS, "t3.micro");
-            } catch (IOException e) {
-                // Expected if the test container is not accessible
-                assertTrue(e.getMessage().contains("Unexpected code") || 
-                          e.getMessage().contains("Connection refused") ||
-                          e.getMessage().contains("Failed to connect"),
-                          "Expected connection-related error, got: " + e.getMessage());
-            }
+    void testGetEnergyEstimatesWithNullProvider() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            client.getEnergyEstimates(null, "t3.micro");
         });
     }
 
@@ -292,82 +157,5 @@ public class BoaviztAPIClientTest extends AbstractBoaviztaTest {
         assertThrows(IllegalArgumentException.class, () -> {
             malformedClient.getEnergyEstimates(Provider.AWS, "t3.micro");
         });
-    }
-
-    @Test
-    void testGetEnergyEstimatesWithHttpsHost() throws IOException {
-        BoaviztAPIClient httpsClient = new BoaviztAPIClient("https://localhost:5000");
-        
-        try {
-            double[] result = httpsClient.getEnergyEstimates(Provider.AWS, "t3.micro");
-            assertNotNull(result);
-            assertEquals(2, result.length);
-        } catch (IOException e) {
-            // Expected if the test container is not accessible or HTTPS not supported
-            assertTrue(e.getMessage().contains("Unexpected code") || 
-                      e.getMessage().contains("Connection refused") ||
-                      e.getMessage().contains("Failed to connect") ||
-                      e.getMessage().contains("SSL") ||
-                      e.getMessage().contains("TLS") ||
-                      e.getMessage().contains("Read timed out"),
-                      "Expected connection-related error, got: " + e.getMessage());
-        }
-    }
-
-    @Test
-    void testGetEnergyEstimatesWithCustomPort() throws IOException {
-        BoaviztAPIClient customPortClient = new BoaviztAPIClient("http://localhost:8080");
-        
-        try {
-            double[] result = customPortClient.getEnergyEstimates(Provider.AWS, "t3.micro");
-            assertNotNull(result);
-            assertEquals(2, result.length);
-        } catch (IOException e) {
-            // Expected if the test container is not accessible on custom port
-            assertTrue(e.getMessage().contains("Unexpected code") || 
-                      e.getMessage().contains("Connection refused") ||
-                      e.getMessage().contains("Failed to connect"),
-                      "Expected connection-related error, got: " + e.getMessage());
-        }
-    }
-
-    @Test
-    void testGetEnergyEstimatesWithInstanceTypeContainingSpaces() throws IOException {
-        try {
-            double[] result = client.getEnergyEstimates(Provider.AWS, "t3 micro");
-            assertNotNull(result);
-            assertEquals(2, result.length);
-        } catch (IOException e) {
-            // Expected if the test container is not accessible
-            assertTrue(e.getMessage().contains("Unexpected code") || 
-                      e.getMessage().contains("Connection refused") ||
-                      e.getMessage().contains("Failed to connect"),
-                      "Expected connection-related error, got: " + e.getMessage());
-        }
-    }
-
-    @Test
-    void testGetEnergyEstimatesWithInstanceTypeContainingUnicode() throws IOException {
-        String[] unicodeInstanceTypes = {
-            "t3.micro-é", 
-            "t3.micro-ñ", 
-            "t3.micro-ü",
-            "t3.micro-中文",
-            "t3.micro-日本語"
-        };
-        
-        for (String instanceType : unicodeInstanceTypes) {
-            try {
-                double[] result = client.getEnergyEstimates(Provider.AWS, instanceType);
-                assertNotNull(result);
-                assertEquals(2, result.length);
-            } catch (IOException e) {
-                // Expected if the test container is not accessible
-                assertTrue(e.getMessage().contains("Unexpected code") || 
-                          e.getMessage().contains("Connection refused") ||
-                          e.getMessage().contains("Failed to connect"),
-                          "Expected connection-related error for " + instanceType + ", got: " + e.getMessage());
-            }
-        }
     }
 }

--- a/src/test/java/com/digitalpebble/spruce/modules/boavizta/BoaviztAPIClientTest.java
+++ b/src/test/java/com/digitalpebble/spruce/modules/boavizta/BoaviztAPIClientTest.java
@@ -7,6 +7,7 @@ import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -18,167 +19,181 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class BoaviztAPIClientTest {
 
-    private MockWebServer mockWebServer;
-    private BoaviztAPIClient client;
     private static final String TEST_HOST = "http://localhost:5000";
 
-    @BeforeEach
-    void setUp() throws IOException {
-        mockWebServer = new MockWebServer();
-        mockWebServer.start(5000);
-        client = new BoaviztAPIClient(TEST_HOST);
-    }
+    @Nested
+    class ValidationTests {
+        private BoaviztAPIClient client;
 
-    @AfterEach
-    void tearDown() throws IOException {
-        mockWebServer.shutdown();
-    }
+        @BeforeEach
+        void setUp() {
+            client = new BoaviztAPIClient(TEST_HOST);
+        }
 
-    @Test
-    void testConstructor() {
-        assertDoesNotThrow(() -> {
-            new BoaviztAPIClient(TEST_HOST);
-        });
-    }
+        @Test
+        void testConstructor() {
+            assertDoesNotThrow(() -> {
+                new BoaviztAPIClient(TEST_HOST);
+            });
+        }
 
-    @ParameterizedTest
-    @MethodSource("invalidHostProvider")
-    void testConstructorWithInvalidHosts(String invalidHost) {
-        assertThrows(IllegalArgumentException.class, () -> {
-            new BoaviztAPIClient(invalidHost);
-        }, "Constructor should throw IllegalArgumentException for invalid host: " + invalidHost);
-    }
+        @ParameterizedTest
+        @MethodSource("invalidHostProvider")
+        void testConstructorWithInvalidHosts(String invalidHost) {
+            assertThrows(IllegalArgumentException.class, () -> {
+                new BoaviztAPIClient(invalidHost);
+            }, "Constructor should throw IllegalArgumentException for invalid host: " + invalidHost);
+        }
 
-    static Stream<String> invalidHostProvider() {
-        return Stream.of(null, "", "   ", "\t", "\n");
-    }
+        static Stream<String> invalidHostProvider() {
+            return Stream.of(null, "", "   ", "\t", "\n");
+        }
 
-    @Test
-    void testGetEnergyEstimatesWithDifferentInstanceTypes() throws IOException {
-        String[] instanceTypes = {"t3.micro", "t3.small", "t3.medium", "c5.large", "m5.xlarge"};
-        
-        for (String instanceType : instanceTypes) {
-            // Mock the API response for this instance type
-            String mockResponse = createMockResponse(instanceType);
-            mockWebServer.enqueue(new MockResponse()
-                .setBody(mockResponse)
-                .setResponseCode(200)
-                .addHeader("Content-Type", "application/json"));
+        @Test
+        void testGetEnergyEstimatesWithNullInstanceType() {
+            assertThrows(IllegalArgumentException.class, () -> {
+                client.getEnergyEstimates(Provider.AWS, null);
+            });
+        }
+
+        @Test
+        void testGetEnergyEstimatesWithEmptyInstanceType() {
+            assertThrows(IllegalArgumentException.class, () -> {
+                client.getEnergyEstimates(Provider.AWS, "");
+            });
+        }
+
+        @Test
+        void testGetEnergyEstimatesWithWhitespaceInstanceType() {
+            assertThrows(IllegalArgumentException.class, () -> {
+                client.getEnergyEstimates(Provider.AWS, "   ");
+            });
+        }
+
+        @Test
+        void testGetEnergyEstimatesWithNullProvider() {
+            assertThrows(IllegalArgumentException.class, () -> {
+                client.getEnergyEstimates(null, "t3.micro");
+            });
+        }
+
+        @Test
+        void testGetEnergyEstimatesWithMalformedHost() {
+            BoaviztAPIClient invalidClient = new BoaviztAPIClient("not-a-valid-url");
             
-            double[] result = client.getEnergyEstimates(Provider.AWS, instanceType);
-            assertNotNull(result);
-            assertEquals(2, result.length);
-            assertTrue(result[0] >= 0, "Use energy should be non-negative for " + instanceType);
-            assertTrue(result[1] >= 0, "Embedded energy should be non-negative for " + instanceType);
+            assertThrows(IllegalArgumentException.class, () -> {
+                invalidClient.getEnergyEstimates(Provider.AWS, "t3.micro");
+            });
         }
     }
 
-    private String createMockResponse(String instanceType) {
-        // Create a realistic mock response based on the BoaviztAPI format
-        return String.format("""
-            {
-                "impacts": {
-                    "pe": {
-                        "use": {
-                            "value": 15.5,
-                            "unit": "MJ"
-                        },
-                        "embedded": {
-                            "value": 120.0,
-                            "unit": "MJ"
+    @Nested
+    class NetworkTests {
+        private MockWebServer mockWebServer;
+        private BoaviztAPIClient client;
+
+        @BeforeEach
+        void setUp() throws IOException {
+            mockWebServer = new MockWebServer();
+            mockWebServer.start(5000);
+            client = new BoaviztAPIClient(TEST_HOST);
+        }
+
+        @AfterEach
+        void tearDown() throws IOException {
+            mockWebServer.shutdown();
+        }
+
+        @Test
+        void testGetEnergyEstimatesWithDifferentInstanceTypes() throws IOException {
+            String[] instanceTypes = {"t3.micro", "t3.small", "t3.medium", "c5.large", "m5.xlarge"};
+            
+            for (String instanceType : instanceTypes) {
+                // Mock the API response for this instance type
+                String mockResponse = createMockResponse(instanceType);
+                mockWebServer.enqueue(new MockResponse()
+                    .setBody(mockResponse)
+                    .setResponseCode(200)
+                    .addHeader("Content-Type", "application/json"));
+                
+                double[] result = client.getEnergyEstimates(Provider.AWS, instanceType);
+                assertNotNull(result);
+                assertEquals(2, result.length);
+                assertTrue(result[0] >= 0, "Use energy should be non-negative for " + instanceType);
+                assertTrue(result[1] >= 0, "Embedded energy should be non-negative for " + instanceType);
+            }
+        }
+
+        @Test
+        void testGetEnergyEstimatesWithDifferentProviders() throws IOException {
+            Provider[] providers = {Provider.AWS, Provider.AZURE, Provider.GOOGLE};
+            
+            for (Provider provider : providers) {
+                // Mock the API response
+                String mockResponse = createMockResponse("t3.micro");
+                mockWebServer.enqueue(new MockResponse()
+                    .setBody(mockResponse)
+                    .setResponseCode(200)
+                    .addHeader("Content-Type", "application/json"));
+                
+                double[] result = client.getEnergyEstimates(provider, "t3.micro");
+                assertNotNull(result);
+                assertEquals(2, result.length);
+            }
+        }
+
+        @Test
+        void testGetEnergyEstimatesWithComplexInstanceTypes() throws IOException {
+            String[] complexInstanceTypes = {
+                "db.r5.24xlarge", 
+                "c5.18xlarge.search", 
+                "m5.12xlarge",
+                "db.t3.micro"
+            };
+            
+            for (String instanceType : complexInstanceTypes) {
+                // Mock the API response
+                String mockResponse = createMockResponse(instanceType);
+                mockWebServer.enqueue(new MockResponse()
+                    .setBody(mockResponse)
+                    .setResponseCode(200)
+                    .addHeader("Content-Type", "application/json"));
+                
+                double[] result = client.getEnergyEstimates(Provider.AWS, instanceType);
+                assertNotNull(result);
+                assertEquals(2, result.length);
+                assertTrue(result[0] >= 0, "Use energy should be non-negative for " + instanceType);
+                assertTrue(result[1] >= 0, "Embedded energy should be non-negative for " + instanceType);
+            }
+        }
+
+        @Test
+        void testGetEnergyEstimatesWithInvalidHost() {
+            BoaviztAPIClient invalidClient = new BoaviztAPIClient("http://invalid-host-that-does-not-exist:9999");
+            
+            assertThrows(IOException.class, () -> {
+                invalidClient.getEnergyEstimates(Provider.AWS, "t3.micro");
+            });
+        }
+
+        private String createMockResponse(String instanceType) {
+            // Create a realistic mock response based on the BoaviztAPI format
+            return String.format("""
+                {
+                    "impacts": {
+                        "pe": {
+                            "use": {
+                                "value": 15.5,
+                                "unit": "MJ"
+                            },
+                            "embedded": {
+                                "value": 120.0,
+                                "unit": "MJ"
+                            }
                         }
                     }
                 }
-            }
-            """);
-    }
-
-    @Test
-    void testGetEnergyEstimatesWithNullInstanceType() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            client.getEnergyEstimates(Provider.AWS, null);
-        });
-    }
-
-    @Test
-    void testGetEnergyEstimatesWithEmptyInstanceType() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            client.getEnergyEstimates(Provider.AWS, "");
-        });
-    }
-
-    @Test
-    void testGetEnergyEstimatesWithWhitespaceInstanceType() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            client.getEnergyEstimates(Provider.AWS, "   ");
-        });
-    }
-
-    @Test
-    void testGetEnergyEstimatesWithDifferentProviders() throws IOException {
-        Provider[] providers = {Provider.AWS, Provider.AZURE, Provider.GOOGLE};
-        
-        for (Provider provider : providers) {
-            // Mock the API response
-            String mockResponse = createMockResponse("t3.micro");
-            mockWebServer.enqueue(new MockResponse()
-                .setBody(mockResponse)
-                .setResponseCode(200)
-                .addHeader("Content-Type", "application/json"));
-            
-            double[] result = client.getEnergyEstimates(provider, "t3.micro");
-            assertNotNull(result);
-            assertEquals(2, result.length);
+                """);
         }
-    }
-
-    @Test
-    void testGetEnergyEstimatesWithComplexInstanceTypes() throws IOException {
-        String[] complexInstanceTypes = {
-            "db.r5.24xlarge", 
-            "c5.18xlarge.search", 
-            "m5.12xlarge",
-            "db.t3.micro"
-        };
-        
-        for (String instanceType : complexInstanceTypes) {
-            // Mock the API response
-            String mockResponse = createMockResponse(instanceType);
-            mockWebServer.enqueue(new MockResponse()
-                .setBody(mockResponse)
-                .setResponseCode(200)
-                .addHeader("Content-Type", "application/json"));
-            
-            double[] result = client.getEnergyEstimates(Provider.AWS, instanceType);
-            assertNotNull(result);
-            assertEquals(2, result.length);
-            assertTrue(result[0] >= 0, "Use energy should be non-negative for " + instanceType);
-            assertTrue(result[1] >= 0, "Embedded energy should be non-negative for " + instanceType);
-        }
-    }
-
-    @Test
-    void testGetEnergyEstimatesWithNullProvider() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            client.getEnergyEstimates(null, "t3.micro");
-        });
-    }
-
-    @Test
-    void testGetEnergyEstimatesWithInvalidHost() {
-        BoaviztAPIClient invalidClient = new BoaviztAPIClient("http://invalid-host-that-does-not-exist:9999");
-        
-        assertThrows(IOException.class, () -> {
-            invalidClient.getEnergyEstimates(Provider.AWS, "t3.micro");
-        });
-    }
-
-    @Test
-    void testGetEnergyEstimatesWithMalformedHost() {
-        BoaviztAPIClient invalidClient = new BoaviztAPIClient("not-a-valid-url");
-        
-        assertThrows(IllegalArgumentException.class, () -> {
-            invalidClient.getEnergyEstimates(Provider.AWS, "t3.micro");
-        });
     }
 }

--- a/src/test/java/com/digitalpebble/spruce/modules/boavizta/BoaviztAPITest.java
+++ b/src/test/java/com/digitalpebble/spruce/modules/boavizta/BoaviztAPITest.java
@@ -2,26 +2,267 @@
 
 package com.digitalpebble.spruce.modules.boavizta;
 
+import com.digitalpebble.spruce.CURColumn;
+import com.digitalpebble.spruce.Column;
+import com.digitalpebble.spruce.SpruceColumn;
 import com.digitalpebble.spruce.Utils;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
 import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class BoaviztAPITest extends AbstractBoaviztaTest {
 
-    BoaviztAPI api = new BoaviztAPI();
-    StructType schema = Utils.getSchema(api);
+    private BoaviztAPI api;
+    private StructType schema;
+
+    @BeforeEach
+    void setUp() {
+        api = new BoaviztAPI();
+        schema = Utils.getSchema(api);
+    }
 
     @Test
-    void testGetEC2() {
+    void testColumnsNeeded() {
+        Column[] needed = api.columnsNeeded();
+        assertEquals(4, needed.length);
+        assertEquals(CURColumn.PRODUCT_INSTANCE_TYPE, needed[0]);
+        assertEquals(CURColumn.PRODUCT_SERVICE_CODE, needed[1]);
+        assertEquals(CURColumn.LINE_ITEM_OPERATION, needed[2]);
+        assertEquals(CURColumn.LINE_ITEM_PRODUCT_CODE, needed[3]);
+    }
+
+    @Test
+    void testColumnsAdded() {
+        Column[] added = api.columnsAdded();
+        assertEquals(1, added.length);
+        assertEquals(SpruceColumn.ENERGY_USED, added[0]);
+    }
+
+    @Test
+    void testInitWithDefaultAddress() {
+        Map<String, Object> params = new HashMap<>();
+        api.init(params);
+        // Should use default address "http://localhost:5000"
+        assertNotNull(api);
+    }
+
+    @Test
+    void testInitWithCustomAddress() {
+        Map<String, Object> params = new HashMap<>();
+        params.put("address", "http://custom-host:8080");
+        api.init(params);
+        // The address should be set to the custom value
+        assertNotNull(api);
+    }
+
+    @Test
+    void testProcessWithNullInstanceType() {
         Object[] values = new Object[]{"AWSDataTransfer", null, null, null, null};
         Row row = new GenericRowWithSchema(values, schema);
         Row enriched = api.process(row);
-        // missing values comes back as it was
+        
+        // Should return the original row unchanged
         assertEquals(row, enriched);
     }
 
+    @Test
+    void testProcessWithNullOperation() {
+        Object[] values = new Object[]{"t3.micro", "AmazonEC2", null, "AmazonEC2", null};
+        Row row = new GenericRowWithSchema(values, schema);
+        Row enriched = api.process(row);
+        
+        // Should return the original row unchanged
+        assertEquals(row, enriched);
+    }
+
+    @Test
+    void testProcessWithNullProductCode() {
+        Object[] values = new Object[]{"t3.micro", "AmazonEC2", "RunInstances", null, null};
+        Row row = new GenericRowWithSchema(values, schema);
+        Row enriched = api.process(row);
+        
+        // Should return the original row unchanged
+        assertEquals(row, enriched);
+    }
+
+    @Test
+    void testProcessWithNullServiceCode() {
+        Object[] values = new Object[]{"t3.micro", null, "RunInstances", "AmazonEC2", null};
+        Row row = new GenericRowWithSchema(values, schema);
+        Row enriched = api.process(row);
+        
+        // Should return the original row unchanged
+        assertEquals(row, enriched);
+    }
+
+    @Test
+    void testProcessWithEmptyInstanceType() {
+        Object[] values = new Object[]{"", "AmazonEC2", "RunInstances", "AmazonEC2", null};
+        Row row = new GenericRowWithSchema(values, schema);
+        Row enriched = api.process(row);
+        
+        // Should return the original row unchanged
+        assertEquals(row, enriched);
+    }
+
+    @Test
+    void testProcessWithWhitespaceInstanceType() {
+        Object[] values = new Object[]{"   ", "AmazonEC2", "RunInstances", "AmazonEC2", null};
+        Row row = new GenericRowWithSchema(values, schema);
+        Row enriched = api.process(row);
+        
+        // Should return the original row unchanged
+        assertEquals(row, enriched);
+    }
+
+    @Test
+    void testProcessUnsupportedService() {
+        Object[] values = new Object[]{"t3.micro", "AmazonS3", "GetObject", "AmazonS3", null};
+        Row row = new GenericRowWithSchema(values, schema);
+        Row enriched = api.process(row);
+        
+        // Should return the original row unchanged for unsupported services
+        assertEquals(row, enriched);
+    }
+
+    @Test
+    void testProcessUnsupportedOperation() {
+        Object[] values = new Object[]{"t3.micro", "AmazonEC2", "StopInstances", "AmazonEC2", null};
+        Row row = new GenericRowWithSchema(values, schema);
+        Row enriched = api.process(row);
+        
+        // Should return the original row unchanged for unsupported operations
+        assertEquals(row, enriched);
+    }
+
+    @Test
+    void testProcessEC2InstanceWithValidData() {
+        Object[] values = new Object[]{"t3.micro", "AmazonEC2", "RunInstances", "AmazonEC2", null};
+        Row row = new GenericRowWithSchema(values, schema);
+        Row enriched = api.process(row);
+        
+        // The row should be processed (may return original if API is not available)
+        assertNotNull(enriched);
+    }
+
+    @Test
+    void testProcessElasticSearchInstanceWithValidData() {
+        Object[] values = new Object[]{"t3.micro.search", "AmazonES", "ESDomain", "AmazonES", null};
+        Row row = new GenericRowWithSchema(values, schema);
+        Row enriched = api.process(row);
+        
+        // The row should be processed (may return original if API is not available)
+        assertNotNull(enriched);
+    }
+
+    @Test
+    void testProcessRDSInstanceWithValidData() {
+        Object[] values = new Object[]{"db.t3.micro", "AmazonRDS", "CreateDBInstance", "AmazonRDS", null};
+        Row row = new GenericRowWithSchema(values, schema);
+        Row enriched = api.process(row);
+        
+        // The row should be processed (may return original if API is not available)
+        assertNotNull(enriched);
+    }
+
+    @Test
+    void testProcessEC2WithDifferentOperationPrefixes() {
+        String[] operations = {"RunInstances", "RunInstances:0002", "RunInstances:0010"};
+        
+        for (String operation : operations) {
+            Object[] values = new Object[]{"t3.micro", "AmazonEC2", operation, "AmazonEC2", null};
+            Row row = new GenericRowWithSchema(values, schema);
+            Row enriched = api.process(row);
+            
+            // The row should be processed (may return original if API is not available)
+            assertNotNull(enriched);
+        }
+    }
+
+    @Test
+    void testProcessRDSWithDifferentOperationPrefixes() {
+        String[] operations = {"CreateDBInstance", "CreateDBInstance:0002", "CreateDBInstance:0010"};
+        
+        for (String operation : operations) {
+            Object[] values = new Object[]{"db.t3.micro", "AmazonRDS", operation, "AmazonRDS", null};
+            Row row = new GenericRowWithSchema(values, schema);
+            Row enriched = api.process(row);
+            
+            // The row should be processed (may return original if API is not available)
+            assertNotNull(enriched);
+        }
+    }
+
+    @Test
+    void testProcessWithComplexInstanceTypes() {
+        String[] instanceTypes = {"db.r5.24xlarge", "c5.18xlarge.search", "m5.12xlarge"};
+        
+        for (String instanceType : instanceTypes) {
+            Object[] values = new Object[]{instanceType, "AmazonEC2", "RunInstances", "AmazonEC2", null};
+            Row row = new GenericRowWithSchema(values, schema);
+            Row enriched = api.process(row);
+            
+            // The row should be processed (may return original if API is not available)
+            assertNotNull(enriched);
+        }
+    }
+
+    @Test
+    void testProcessWithMixedCaseServiceCodes() {
+        Object[] values = new Object[]{"t3.micro", "amazonec2", "RunInstances", "AmazonEC2", null};
+        Row row = new GenericRowWithSchema(values, schema);
+        Row enriched = api.process(row);
+        
+        // Should return the original row unchanged for case-sensitive service codes
+        assertEquals(row, enriched);
+    }
+
+    @Test
+    void testProcessWithSpecialCharactersInInstanceType() {
+        Object[] values = new Object[]{"t3.micro@test", "AmazonEC2", "RunInstances", "AmazonEC2", null};
+        Row row = new GenericRowWithSchema(values, schema);
+        Row enriched = api.process(row);
+        
+        // The row should be processed (may return original if API is not available)
+        assertNotNull(enriched);
+    }
+
+    @Test
+    void testProcessWithVeryLongInstanceType() {
+        String longInstanceType = "t3.micro".repeat(100); // Create a very long instance type
+        Object[] values = new Object[]{longInstanceType, "AmazonEC2", "RunInstances", "AmazonEC2", null};
+        Row row = new GenericRowWithSchema(values, schema);
+        Row enriched = api.process(row);
+        
+        // The row should be processed (may return original if API is not available)
+        assertNotNull(enriched);
+    }
+
+    @Test
+    void testProcessWithNullValuesInAllFields() {
+        Object[] values = new Object[]{null, null, null, null, null};
+        Row row = new GenericRowWithSchema(values, schema);
+        Row enriched = api.process(row);
+        
+        // Should return the original row unchanged
+        assertEquals(row, enriched);
+    }
+
+    @Test
+    void testProcessWithEmptyStringsInAllFields() {
+        Object[] values = new Object[]{"", "", "", "", null};
+        Row row = new GenericRowWithSchema(values, schema);
+        Row enriched = api.process(row);
+        
+        // Should return the original row unchanged
+        assertEquals(row, enriched);
+    }
 }

--- a/src/test/java/com/digitalpebble/spruce/modules/boavizta/BoaviztAPITest.java
+++ b/src/test/java/com/digitalpebble/spruce/modules/boavizta/BoaviztAPITest.java
@@ -20,8 +20,8 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BoaviztAPITest extends AbstractBoaviztaTest {
@@ -54,19 +54,21 @@ public class BoaviztAPITest extends AbstractBoaviztaTest {
 
     @Test
     void testInitWithDefaultAddress() {
-        Map<String, Object> params = new HashMap<>();
-        api.init(params);
-        // Should use default address "http://localhost:5000"
-        assertNotNull(api);
+        assertDoesNotThrow(() -> {
+            Map<String, Object> params = new HashMap<>();
+            api.init(params);
+            // Should use default address "http://localhost:5000"
+        });
     }
 
     @Test
     void testInitWithCustomAddress() {
-        Map<String, Object> params = new HashMap<>();
-        params.put("address", "http://custom-host:8080");
-        api.init(params);
-        // The address should be set to the custom value
-        assertNotNull(api);
+        assertDoesNotThrow(() -> {
+            Map<String, Object> params = new HashMap<>();
+            params.put("address", "http://custom-host:8080");
+            api.init(params);
+            // The address should be set to the custom value
+        });
     }
 
     @ParameterizedTest

--- a/src/test/java/com/digitalpebble/spruce/modules/boavizta/BoaviztAPITest.java
+++ b/src/test/java/com/digitalpebble/spruce/modules/boavizta/BoaviztAPITest.java
@@ -6,15 +6,20 @@ import com.digitalpebble.spruce.CURColumn;
 import com.digitalpebble.spruce.Column;
 import com.digitalpebble.spruce.SpruceColumn;
 import com.digitalpebble.spruce.Utils;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
 import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -24,230 +29,318 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BoaviztAPITest extends AbstractBoaviztaTest {
+public class BoaviztAPITest {
 
-    private BoaviztAPI api;
-    private StructType schema;
+    private static final String TEST_HOST = "http://localhost:5000";
 
-    @BeforeEach
-    void setUp() {
-        api = new BoaviztAPI();
-        schema = Utils.getSchema(api);
-    }
+    @Nested
+    class ValidationTests {
+        private BoaviztAPI api;
+        private StructType schema;
 
-    @Test
-    void testColumnsNeeded() {
-        Column[] needed = api.columnsNeeded();
-        assertEquals(4, needed.length);
-        assertEquals(CURColumn.PRODUCT_INSTANCE_TYPE, needed[0]);
-        assertEquals(CURColumn.PRODUCT_SERVICE_CODE, needed[1]);
-        assertEquals(CURColumn.LINE_ITEM_OPERATION, needed[2]);
-        assertEquals(CURColumn.LINE_ITEM_PRODUCT_CODE, needed[3]);
-    }
+        @BeforeEach
+        void setUp() {
+            api = new BoaviztAPI();
+            schema = Utils.getSchema(api);
+        }
 
-    @Test
-    void testColumnsAdded() {
-        Column[] added = api.columnsAdded();
-        assertEquals(1, added.length);
-        assertEquals(SpruceColumn.ENERGY_USED, added[0]);
-    }
+        @Test
+        void testColumnsNeeded() {
+            Column[] needed = api.columnsNeeded();
+            assertEquals(4, needed.length);
+            assertEquals(CURColumn.PRODUCT_INSTANCE_TYPE, needed[0]);
+            assertEquals(CURColumn.PRODUCT_SERVICE_CODE, needed[1]);
+            assertEquals(CURColumn.LINE_ITEM_OPERATION, needed[2]);
+            assertEquals(CURColumn.LINE_ITEM_PRODUCT_CODE, needed[3]);
+        }
 
-    @Test
-    void testInitWithDefaultAddress() {
-        assertDoesNotThrow(() -> {
-            Map<String, Object> params = new HashMap<>();
-            api.init(params);
-            // Should use default address "http://localhost:5000"
-        });
-    }
+        @Test
+        void testColumnsAdded() {
+            Column[] added = api.columnsAdded();
+            assertEquals(1, added.length);
+            assertEquals(SpruceColumn.ENERGY_USED, added[0]);
+        }
 
-    @Test
-    void testInitWithCustomAddress() {
-        assertDoesNotThrow(() -> {
-            Map<String, Object> params = new HashMap<>();
-            params.put("address", "http://custom-host:8080");
-            api.init(params);
-            // The address should be set to the custom value
-        });
-    }
+        @Test
+        void testInitWithDefaultAddress() {
+            assertDoesNotThrow(() -> {
+                Map<String, Object> params = new HashMap<>();
+                api.init(params);
+                // Should use default address "http://localhost:5000"
+            });
+        }
 
-    @ParameterizedTest
-    @MethodSource("nullValueTestCases")
-    void testProcessWithNullValues(String instanceType, String serviceCode, String operation, String productCode) {
-        Object[] values = new Object[]{instanceType, serviceCode, operation, productCode, null};
-        Row row = new GenericRowWithSchema(values, schema);
-        Row enriched = api.process(row);
-        
-        // Should return the original row unchanged
-        assertEquals(row, enriched);
-    }
+        @Test
+        void testInitWithCustomAddress() {
+            assertDoesNotThrow(() -> {
+                Map<String, Object> params = new HashMap<>();
+                params.put("address", "http://custom-host:8080");
+                api.init(params);
+                // The address should be set to the custom value
+            });
+        }
 
-    static Stream<Arguments> nullValueTestCases() {
-        return Stream.of(
-            Arguments.of("AWSDataTransfer", null, null, null),
-            Arguments.of("t3.micro", "AmazonEC2", null, "AmazonEC2"),
-            Arguments.of("t3.micro", "AmazonEC2", "RunInstances", null),
-            Arguments.of("t3.micro", null, "RunInstances", "AmazonEC2"),
-            Arguments.of(null, null, null, null)
-        );
-    }
-
-    @ParameterizedTest
-    @MethodSource("emptyValueTestCases")
-    void testProcessWithEmptyValues(String instanceType, String serviceCode, String operation, String productCode) {
-        Object[] values = new Object[]{instanceType, serviceCode, operation, productCode, null};
-        Row row = new GenericRowWithSchema(values, schema);
-        
-        // Test cases 1 and 2 (null and empty instance types) should throw IllegalArgumentException
-        // Test cases 3 and 4 (empty strings for all fields) should return unchanged rows
-        // because BoaviztAPI.process() has early returns before calling BoaviztAPIClient.getEnergyEstimates()
-        if (instanceType == null || (instanceType != null && instanceType.trim().isEmpty())) {
-            // These should throw IllegalArgumentException if they reach the API call
-            try {
-                Row enriched = api.process(row);
-                // If no exception was thrown, the row should be unchanged
-                assertEquals(row, enriched, "Should return unchanged row for null/empty instance types that don't reach API call");
-            } catch (IllegalArgumentException e) {
-                // This is also valid - the validation caught it
-                assertTrue(e.getMessage().contains("Instance type cannot be null, empty, or whitespace only"));
-            }
-        } else {
-            // Other test cases should return unchanged rows
+        @ParameterizedTest
+        @MethodSource("nullValueTestCases")
+        void testProcessWithNullValues(String instanceType, String serviceCode, String operation, String productCode) {
+            Object[] values = new Object[]{instanceType, serviceCode, operation, productCode, null};
+            Row row = new GenericRowWithSchema(values, schema);
             Row enriched = api.process(row);
-            assertEquals(row, enriched, "Should return unchanged row for other empty value cases");
+            
+            // Should return the original row unchanged
+            assertEquals(row, enriched);
+        }
+
+        static Stream<Arguments> nullValueTestCases() {
+            return Stream.of(
+                Arguments.of("AWSDataTransfer", null, null, null),
+                Arguments.of("t3.micro", "AmazonEC2", null, "AmazonEC2"),
+                Arguments.of("t3.micro", "AmazonEC2", "RunInstances", null),
+                Arguments.of("t3.micro", null, "RunInstances", "AmazonEC2"),
+                Arguments.of(null, null, null, null)
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("emptyValueTestCases")
+        void testProcessWithEmptyValues(String instanceType, String serviceCode, String operation, String productCode) {
+            Object[] values = new Object[]{instanceType, serviceCode, operation, productCode, null};
+            Row row = new GenericRowWithSchema(values, schema);
+            
+            // Test cases 1 and 2 (null and empty instance types) should throw IllegalArgumentException
+            // Test cases 3 and 4 (empty strings for all fields) should return unchanged rows
+            // because BoaviztAPI.process() has early returns before calling BoaviztAPIClient.getEnergyEstimates()
+            if (instanceType == null || (instanceType != null && instanceType.trim().isEmpty())) {
+                // These should throw IllegalArgumentException if they reach the API call
+                try {
+                    Row enriched = api.process(row);
+                    // If no exception was thrown, the row should be unchanged
+                    assertEquals(row, enriched, "Should return unchanged row for null/empty instance types that don't reach API call");
+                } catch (IllegalArgumentException e) {
+                    // This is also valid - the validation caught it
+                    assertTrue(e.getMessage().contains("Instance type cannot be null, empty, or whitespace only"));
+                }
+            } else {
+                // Other test cases should return unchanged rows
+                Row enriched = api.process(row);
+                assertEquals(row, enriched, "Should return unchanged row for other empty value cases");
+            }
+        }
+
+        static Stream<Arguments> emptyValueTestCases() {
+            return Stream.of(
+                Arguments.of("", "AmazonEC2", "RunInstances", "AmazonEC2"),
+                Arguments.of("   ", "AmazonEC2", "RunInstances", "AmazonEC2"),
+                Arguments.of("", "", "", ""),
+                Arguments.of("   ", "   ", "   ", "   ")
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("unsupportedValueTestCases")
+        void testProcessWithUnsupportedValues(String instanceType, String serviceCode, String operation, String productCode) {
+            Object[] values = new Object[]{instanceType, serviceCode, operation, productCode, null};
+            Row row = new GenericRowWithSchema(values, schema);
+            Row enriched = api.process(row);
+            
+            // Should return the original row unchanged for unsupported services/operations
+            assertEquals(row, enriched);
+        }
+
+        static Stream<Arguments> unsupportedValueTestCases() {
+            return Stream.of(
+                Arguments.of("t3.micro", "AmazonS3", "GetObject", "AmazonS3"),
+                Arguments.of("t3.micro", "AmazonEC2", "StopInstances", "AmazonEC2"),
+                Arguments.of("t3.micro", "amazonec2", "RunInstances", "AmazonEC2")
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("edgeCaseTestCases")
+        void testProcessWithEdgeCases(String instanceType, String serviceCode, String operation, String productCode) {
+            Object[] values = new Object[]{instanceType, serviceCode, operation, productCode, null};
+            Row row = new GenericRowWithSchema(values, schema);
+            Row enriched = api.process(row);
+            
+            // Should return the original row unchanged for edge cases
+            assertEquals(row, enriched);
+        }
+
+        static Stream<Arguments> edgeCaseTestCases() {
+            return Stream.of(
+                Arguments.of("t3.micro@test", "AmazonEC2", "RunInstances", "AmazonEC2"),
+                Arguments.of("t3.micro".repeat(100), "AmazonEC2", "RunInstances", "AmazonEC2")
+            );
         }
     }
 
-    static Stream<Arguments> emptyValueTestCases() {
-        return Stream.of(
-            Arguments.of("", "AmazonEC2", "RunInstances", "AmazonEC2"),
-            Arguments.of("   ", "AmazonEC2", "RunInstances", "AmazonEC2"),
-            Arguments.of("", "", "", ""),
-            Arguments.of("   ", "   ", "   ", "   ")
-        );
-    }
+    @Nested
+    class NetworkTests {
+        private MockWebServer mockWebServer;
+        private BoaviztAPI api;
+        private StructType schema;
 
-    @ParameterizedTest
-    @MethodSource("unsupportedValueTestCases")
-    void testProcessWithUnsupportedValues(String instanceType, String serviceCode, String operation, String productCode) {
-        Object[] values = new Object[]{instanceType, serviceCode, operation, productCode, null};
-        Row row = new GenericRowWithSchema(values, schema);
-        Row enriched = api.process(row);
-        
-        // Should return the original row unchanged for unsupported services/operations
-        assertEquals(row, enriched);
-    }
+        @BeforeEach
+        void setUp() throws IOException {
+            mockWebServer = new MockWebServer();
+            mockWebServer.start(5000);
+            api = new BoaviztAPI();
+            schema = Utils.getSchema(api);
+        }
 
-    static Stream<Arguments> unsupportedValueTestCases() {
-        return Stream.of(
-            Arguments.of("t3.micro", "AmazonS3", "GetObject", "AmazonS3"),
-            Arguments.of("t3.micro", "AmazonEC2", "StopInstances", "AmazonEC2"),
-            Arguments.of("t3.micro", "amazonec2", "RunInstances", "AmazonEC2")
-        );
-    }
+        @AfterEach
+        void tearDown() throws IOException {
+            mockWebServer.shutdown();
+        }
 
-    @ParameterizedTest
-    @MethodSource("edgeCaseTestCases")
-    void testProcessWithEdgeCases(String instanceType, String serviceCode, String operation, String productCode) {
-        Object[] values = new Object[]{instanceType, serviceCode, operation, productCode, null};
-        Row row = new GenericRowWithSchema(values, schema);
-        Row enriched = api.process(row);
-        
-        // Should return the original row unchanged for edge cases
-        assertEquals(row, enriched);
-    }
+        @Test
+        void testProcessEC2InstanceWithValidData() throws IOException {
+            // Mock the API response
+            String mockResponse = createMockResponse("t3.micro");
+            mockWebServer.enqueue(new MockResponse()
+                .setBody(mockResponse)
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json"));
 
-    static Stream<Arguments> edgeCaseTestCases() {
-        return Stream.of(
-            Arguments.of("t3.micro@test", "AmazonEC2", "RunInstances", "AmazonEC2"),
-            Arguments.of("t3.micro".repeat(100), "AmazonEC2", "RunInstances", "AmazonEC2")
-        );
-    }
+            Object[] values = new Object[]{"t3.micro", "AmazonEC2", "RunInstances", "AmazonEC2", null};
+            Row row = new GenericRowWithSchema(values, schema);
+            Row enriched = api.process(row);
+            
+            // The row should be processed and enriched with energy data
+            assertNotNull(enriched);
+            // Verify that the row was enriched (you can add more specific assertions here)
+        }
 
-    @Test
-    void testProcessEC2InstanceWithValidData() {
-        Object[] values = new Object[]{"t3.micro", "AmazonEC2", "RunInstances", "AmazonEC2", null};
-        Row row = new GenericRowWithSchema(values, schema);
-        Row enriched = api.process(row);
-        
-        // The row should be processed (may return original if API is not available)
-        assertNotNull(enriched);
-    }
+        @Test
+        void testProcessElasticSearchInstanceWithValidData() throws IOException {
+            // Mock the API response
+            String mockResponse = createMockResponse("t3.micro");
+            mockWebServer.enqueue(new MockResponse()
+                .setBody(mockResponse)
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json"));
 
-    @Test
-    void testProcessElasticSearchInstanceWithValidData() {
-        Object[] values = new Object[]{"t3.micro.search", "AmazonES", "ESDomain", "AmazonES", null};
-        Row row = new GenericRowWithSchema(values, schema);
-        Row enriched = api.process(row);
-        
-        // The row should be processed (may return original if API is not available)
-        assertNotNull(enriched);
-    }
+            Object[] values = new Object[]{"t3.micro.search", "AmazonES", "ESDomain", "AmazonES", null};
+            Row row = new GenericRowWithSchema(values, schema);
+            Row enriched = api.process(row);
+            
+            // The row should be processed and enriched with energy data
+            assertNotNull(enriched);
+        }
 
-    @Test
-    void testProcessRDSInstanceWithValidData() {
-        Object[] values = new Object[]{"db.t3.micro", "AmazonRDS", "CreateDBInstance", "AmazonRDS", null};
-        Row row = new GenericRowWithSchema(values, schema);
-        Row enriched = api.process(row);
-        
-        // The row should be processed (may return original if API is not available)
-        assertNotNull(enriched);
-    }
+        @Test
+        void testProcessRDSInstanceWithValidData() throws IOException {
+            // Mock the API response
+            String mockResponse = createMockResponse("t3.micro");
+            mockWebServer.enqueue(new MockResponse()
+                .setBody(mockResponse)
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json"));
 
-    @ParameterizedTest
-    @MethodSource("validEC2OperationTestCases")
-    void testProcessEC2WithDifferentOperationPrefixes(String operation) {
-        Object[] values = new Object[]{"t3.micro", "AmazonEC2", operation, "AmazonEC2", null};
-        Row row = new GenericRowWithSchema(values, schema);
-        Row enriched = api.process(row);
-        
-        // The row should be processed (may return original if API is not available)
-        assertNotNull(enriched);
-    }
+            Object[] values = new Object[]{"db.t3.micro", "AmazonRDS", "CreateDBInstance", "AmazonRDS", null};
+            Row row = new GenericRowWithSchema(values, schema);
+            Row enriched = api.process(row);
+            
+            // The row should be processed and enriched with energy data
+            assertNotNull(enriched);
+        }
 
-    static Stream<Arguments> validEC2OperationTestCases() {
-        return Stream.of(
-            Arguments.of("RunInstances"),
-            Arguments.of("RunInstances:0002"),
-            Arguments.of("RunInstances:0010")
-        );
-    }
+        @ParameterizedTest
+        @MethodSource("validEC2OperationTestCases")
+        void testProcessEC2WithDifferentOperationPrefixes(String operation) throws IOException {
+            // Mock the API response
+            String mockResponse = createMockResponse("t3.micro");
+            mockWebServer.enqueue(new MockResponse()
+                .setBody(mockResponse)
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json"));
 
-    @ParameterizedTest
-    @MethodSource("validRDSOperationTestCases")
-    void testProcessRDSWithDifferentOperationPrefixes(String operation) {
-        Object[] values = new Object[]{"db.t3.micro", "AmazonRDS", operation, "AmazonRDS", null};
-        Row row = new GenericRowWithSchema(values, schema);
-        Row enriched = api.process(row);
-        
-        // The row should be processed (may return original if API is not available)
-        assertNotNull(enriched);
-    }
+            Object[] values = new Object[]{"t3.micro", "AmazonEC2", operation, "AmazonEC2", null};
+            Row row = new GenericRowWithSchema(values, schema);
+            Row enriched = api.process(row);
+            
+            // The row should be processed and enriched with energy data
+            assertNotNull(enriched);
+        }
 
-    static Stream<Arguments> validRDSOperationTestCases() {
-        return Stream.of(
-            Arguments.of("CreateDBInstance"),
-            Arguments.of("CreateDBInstance:0002"),
-            Arguments.of("CreateDBInstance:0010")
-        );
-    }
+        static Stream<Arguments> validEC2OperationTestCases() {
+            return Stream.of(
+                Arguments.of("RunInstances"),
+                Arguments.of("RunInstances:0002"),
+                Arguments.of("RunInstances:0010")
+            );
+        }
 
-    @ParameterizedTest
-    @MethodSource("complexInstanceTypeTestCases")
-    void testProcessWithComplexInstanceTypes(String instanceType) {
-        Object[] values = new Object[]{instanceType, "AmazonEC2", "RunInstances", "AmazonEC2", null};
-        Row row = new GenericRowWithSchema(values, schema);
-        Row enriched = api.process(row);
-        
-        // The row should be processed (may return original if API is not available)
-        assertNotNull(enriched);
-    }
+        @ParameterizedTest
+        @MethodSource("validRDSOperationTestCases")
+        void testProcessRDSWithDifferentOperationPrefixes(String operation) throws IOException {
+            // Mock the API response
+            String mockResponse = createMockResponse("t3.micro");
+            mockWebServer.enqueue(new MockResponse()
+                .setBody(mockResponse)
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json"));
 
-    static Stream<Arguments> complexInstanceTypeTestCases() {
-        return Stream.of(
-            Arguments.of("db.r5.24xlarge"),
-            Arguments.of("c5.18xlarge.search"),
-            Arguments.of("m5.12xlarge")
-        );
+            Object[] values = new Object[]{"db.t3.micro", "AmazonRDS", operation, "AmazonRDS", null};
+            Row row = new GenericRowWithSchema(values, schema);
+            Row enriched = api.process(row);
+            
+            // The row should be processed and enriched with energy data
+            assertNotNull(enriched);
+        }
+
+        static Stream<Arguments> validRDSOperationTestCases() {
+            return Stream.of(
+                Arguments.of("CreateDBInstance"),
+                Arguments.of("CreateDBInstance:0002"),
+                Arguments.of("CreateDBInstance:0010")
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("complexInstanceTypeTestCases")
+        void testProcessWithComplexInstanceTypes(String instanceType) throws IOException {
+            // Mock the API response
+            String mockResponse = createMockResponse(instanceType);
+            mockWebServer.enqueue(new MockResponse()
+                .setBody(mockResponse)
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json"));
+
+            Object[] values = new Object[]{instanceType, "AmazonEC2", "RunInstances", "AmazonEC2", null};
+            Row row = new GenericRowWithSchema(values, schema);
+            Row enriched = api.process(row);
+            
+            // The row should be processed and enriched with energy data
+            assertNotNull(enriched);
+        }
+
+        static Stream<Arguments> complexInstanceTypeTestCases() {
+            return Stream.of(
+                Arguments.of("db.r5.24xlarge"),
+                Arguments.of("c5.18xlarge.search"),
+                Arguments.of("m5.12xlarge")
+            );
+        }
+
+        private String createMockResponse(String instanceType) {
+            // Create a realistic mock response based on the BoaviztAPI format
+            return String.format("""
+                {
+                    "impacts": {
+                        "pe": {
+                            "use": {
+                                "value": 15.5,
+                                "unit": "MJ"
+                            },
+                            "embedded": {
+                                "value": 120.0,
+                                "unit": "MJ"
+                            }
+                        }
+                    }
+                }
+                """);
+        }
     }
 }


### PR DESCRIPTION
# In this PR
- Added tests around BoaviztAPI module addressing [issue#16](https://github.com/DigitalPebble/spruce/issues/16)
- BoaviztAPIClientTest covers BoaviztAPIClient
- BoaviztAPITest covers BoaviztAPI

```
[INFO] Tests run: 22, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 110.3 s -- in com.digitalpebble.spruce.modules.boavizta.BoaviztAPIClientTest
[INFO] Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 65.08 s -- in com.digitalpebble.spruce.modules.boavizta.BoaviztAPITest

```

<img width="757" height="157" alt="Screenshot 2025-08-20 at 1 47 51 PM" src="https://github.com/user-attachments/assets/9b6b5a31-9682-484d-8ce7-e1e87aa26b8f" />
