### PR TITLE
Computation operational emissions in a separate module

### DIFF
--- a/src/main/java/com/digitalpebble/spruce/modules/OperationalEmissions.java
+++ b/src/main/java/com/digitalpebble/spruce/modules/OperationalEmissions.java
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalpebble.spruce.modules;
+
+import com.digitalpebble.spruce.Column;
+import com.digitalpebble.spruce.EnrichmentModule;
+import org.apache.spark.sql.Row;
+
+import static com.digitalpebble.spruce.SpruceColumn.*;
+
+/**
+ * Populate the field OPERATIONAL_EMISSIONS
+ * for rows where energy usage has been estimated, taking into account the PUE if present.
+ **/
+public class OperationalEmissions implements EnrichmentModule {
+
+    @Override
+    public Column[] columnsNeeded() {
+        return new Column[]{ENERGY_USED, CARBON_INTENSITY, PUE};
+    }
+
+    @Override
+    public Column[] columnsAdded() {
+        return new Column[]{OPERATIONAL_EMISSIONS};
+    }
+
+    @Override
+    public Row process(Row row) {
+        if (ENERGY_USED.isNullAt(row)) {
+            return row;
+        }
+
+        if (CARBON_INTENSITY.isNullAt(row)) {
+            return row;
+        }
+
+        final double energyUsed = ENERGY_USED.getDouble(row);
+
+        // take into account the PUE if present
+        final double pue = PUE.isNullAt(row) ? 1.0 : PUE.getDouble(row);
+        final double carbon_intensity = CARBON_INTENSITY.getDouble(row);
+        final double emissions = energyUsed * carbon_intensity * pue;
+
+        return EnrichmentModule.withUpdatedValue(row, OPERATIONAL_EMISSIONS, emissions);
+    }
+}

--- a/src/main/java/com/digitalpebble/spruce/modules/electricitymaps/AverageCarbonIntensity.java
+++ b/src/main/java/com/digitalpebble/spruce/modules/electricitymaps/AverageCarbonIntensity.java
@@ -17,8 +17,8 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Populate the CARBON_INTENSITY and OPERATIONAL_EMISSIONS using ElecticityMaps' 2024 datasets
- * for rows where energy usage has been estimated. Takes into account the PUE if present.
+ * Populate the CARBON_INTENSITY field using ElecticityMaps' 2024 datasets
+ * for rows where energy usage has been estimated.
  **/
 public class AverageCarbonIntensity implements EnrichmentModule {
 
@@ -51,7 +51,7 @@ public class AverageCarbonIntensity implements EnrichmentModule {
 
     @Override
     public Column[] columnsNeeded() {
-        return new Column[]{ENERGY_USED, PRODUCT_REGION_CODE, PRODUCT_FROM_REGION_CODE, PRODUCT_TO_REGION_CODE, PUE};
+        return new Column[]{ENERGY_USED, PRODUCT_REGION_CODE, PRODUCT_FROM_REGION_CODE, PRODUCT_TO_REGION_CODE};
     }
 
     /**
@@ -65,7 +65,7 @@ public class AverageCarbonIntensity implements EnrichmentModule {
 
     @Override
     public Column[] columnsAdded() {
-        return new Column[]{CARBON_INTENSITY, OPERATIONAL_EMISSIONS};
+        return new Column[]{CARBON_INTENSITY};
     }
 
     @Override
@@ -99,16 +99,7 @@ public class AverageCarbonIntensity implements EnrichmentModule {
                 // if the coefficient is 0 it means that the region is not supported
                 return row;
             }
-
-            // take into account the PUE if present
-            double pue = PUE.isNullAt(row)? 1.0 : PUE.getDouble(row);
-
-            // compute the usage emissions
-            double emissions = energyUsed * coeff * pue;
-            Map<Column, Object> additions = new HashMap<>();
-            additions.put(CARBON_INTENSITY, coeff);
-            additions.put(OPERATIONAL_EMISSIONS, emissions);
-            return EnrichmentModule.withUpdatedValues(row, additions);
+            return EnrichmentModule.withUpdatedValue(row, CARBON_INTENSITY, coeff);
         } catch (Exception exception) {
             // if the region is not supported, we cannot compute the carbon intensity
             return row;

--- a/src/main/resources/default-config.json
+++ b/src/main/resources/default-config.json
@@ -23,9 +23,10 @@
       "className": "com.digitalpebble.spruce.modules.ccf.PUE"
     },
     {
-      "className": "com.digitalpebble.spruce.modules.electricitymaps.AverageCarbonIntensity",
-      "config": {
-      }
+      "className": "com.digitalpebble.spruce.modules.electricitymaps.AverageCarbonIntensity"
+    },
+    {
+      "className": "com.digitalpebble.spruce.modules.OperationalEmissions"
     }
   ]
 }

--- a/src/test/java/com/digitalpebble/spruce/modules/OperationalEmissionsTest.java
+++ b/src/test/java/com/digitalpebble/spruce/modules/OperationalEmissionsTest.java
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalpebble.spruce.modules;
+
+import com.digitalpebble.spruce.Utils;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+
+import static com.digitalpebble.spruce.SpruceColumn.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class OperationalEmissionsTest {
+
+    private OperationalEmissions module = new OperationalEmissions();
+
+    // ENERGY_USED, CARBON_INTENSITY, PUE, OPERATIONAL_EMISSIONS
+    private StructType schema = Utils.getSchema(module);
+
+    @Test
+    void processNoValues() {
+        Object[] values = new Object[] {null, null, null};
+        Row row = new GenericRowWithSchema(values, schema);
+        Row enriched = module.process(row);
+        // missing values comes back as it was
+        assertEquals(row, enriched);
+    }
+
+    @Test
+    void processNoPUE() {
+        Object[] values = new Object[] {10d, 321.04d, null, null};
+        Row row = new GenericRowWithSchema(values, schema);
+        Row enriched = module.process(row);
+        double expected = 10 * 321.04;
+        double result = OPERATIONAL_EMISSIONS.getDouble(enriched);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void processWithPUE() {
+        Object[] values = new Object[] {10d, 321.04d, 1.15, null};
+        Row row = new GenericRowWithSchema(values, schema);
+        Row enriched = module.process(row);
+        double expected = 10 * 321.04 * 1.15;
+        double result = OPERATIONAL_EMISSIONS.getDouble(enriched);
+        assertEquals(expected, result);
+    }
+
+}


### PR DESCRIPTION
fix #25

The handling of the carbon intensities is now separate from the computation of the operational emissions.