### PR TITLE
Improve storage footprint from CCF

### DIFF
--- a/src/main/java/com/digitalpebble/spruce/CURColumn.java
+++ b/src/main/java/com/digitalpebble/spruce/CURColumn.java
@@ -14,6 +14,7 @@ public class CURColumn extends Column {
     public static Column LINE_ITEM_PRODUCT_CODE = new CURColumn("line_item_product_code", StringType);
     public static Column LINE_ITEM_TYPE = new CURColumn("line_item_line_item_type", StringType);
     public static Column LINE_ITEM_USAGE_TYPE = new CURColumn("line_item_usage_type", StringType);
+    public static Column PRICING_UNIT= new CURColumn("pricing_unit", StringType);
     public static Column PRODUCT = new CURColumn("product", MapType.apply(StringType,StringType));
     public static Column PRODUCT_INSTANCE_TYPE = new CURColumn("product_instance_type", StringType);
     public static Column PRODUCT_PRODUCT_FAMILY = new CURColumn("product_product_family", StringType);

--- a/src/main/resources/ccf/storage.json
+++ b/src/main/resources/ccf/storage.json
@@ -95,5 +95,12 @@
     "AMP:MetricStorageByteHrs",
     "TimedStorage-INT-AIA-ByteHrs",
     "TimedStorage-GIR-ByteHrs"
+  ],
+  "KNOWN_USAGE_UNITS" : [
+    "GB-Hours",
+    "GB-Mo",
+    "GB-Month",
+    "GB-Mp",
+    "GB-month"
   ]
 }

--- a/src/test/java/com/digitalpebble/spruce/modules/ccf/StorageTest.java
+++ b/src/test/java/com/digitalpebble/spruce/modules/ccf/StorageTest.java
@@ -27,7 +27,7 @@ class StorageTest {
 
     @Test
     void processCreateVolumeSSD() {
-        Object[] values = new Object[]{"CreateVolume-Gp3", 10d, null, null, null};
+        Object[] values = new Object[]{"CreateVolume-Gp3", 10d, null, null, null, null};
         Row row = new GenericRowWithSchema(values, schema);
         Row result = storage.process(row);
         double expected = 10d * storage.ssd_gb_coefficient;
@@ -36,7 +36,7 @@ class StorageTest {
 
     @Test
     void processCreateVolumeSSD2() {
-        Object[] values = new Object[]{"CreateVolume-Gp2", 10d, null, null, null};
+        Object[] values = new Object[]{"CreateVolume-Gp2", 10d, null, null, null, null};
         Row row = new GenericRowWithSchema(values, schema);
         Row result = storage.process(row);
         double expected = 10d * storage.ssd_gb_coefficient;
@@ -45,7 +45,7 @@ class StorageTest {
 
     @Test
     void processCreateVolumeHDD() {
-        Object[] values = new Object[]{"CreateVolume", 10d, null, null, null};
+        Object[] values = new Object[]{"CreateVolume", 10d, null, null, null, null};
         Row row = new GenericRowWithSchema(values, schema);
         Row result = storage.process(row);
         double expected = 10d * storage.hdd_gb_coefficient;
@@ -54,7 +54,7 @@ class StorageTest {
 
     @Test
     void processS3() {
-        Object[] values = new Object[]{"Storage", 10d, "EUW2-TimedStorage-ByteHrs", null, null};
+        Object[] values = new Object[]{"Storage", 10d, "EUW2-TimedStorage-ByteHrs", null, "GB-Mo", null};
         Row row = new GenericRowWithSchema(values, schema);
         Row result = storage.process(row);
         double expected = 10d * storage.hdd_gb_coefficient;
@@ -63,10 +63,19 @@ class StorageTest {
 
     @Test
     void processSSDService() {
-        Object[] values = new Object[]{"Storage", 10d, "SomeUsageType", "AmazonFSx", null};
+        Object[] values = new Object[]{"Storage", 10d, "SomeUsageType", "AmazonDocDB", "GB-Mo", null};
         Row row = new GenericRowWithSchema(values, schema);
         Row result = storage.process(row);
         double expected = 10d * storage.ssd_gb_coefficient;
         assertEquals(expected, ENERGY_USED.getDouble(result));
     }
+
+    @Test
+    void processSSDServiceWrongUInit() {
+        Object[] values = new Object[]{"Storage", 10d, "SomeUsageType", "AmazonDocDB", "vCPU-hour", null};
+        Row row = new GenericRowWithSchema(values, schema);
+        Row result = storage.process(row);
+        assertEquals(row, result);
+    }
+
 }


### PR DESCRIPTION
Finishes the estimation of storage footprint from CCF

https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/blob/9f2cf436e5ad020830977e52c3b0a1719d20a8b9/packages/aws/src/lib/CostAndUsageReports.ts#L350

We use the same resources as CCF to filter rows that have a pricing unit  indicating storage then check in the list of usage types indicating HDD or SSD, finally  compare with a list of services that are likely to be backed by SSD.

