### PR TITLE
Deps upgrades commons-cli, mockito, caffeine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,10 @@
         <maven.compiler.target>17</maven.compiler.target>
         <spark.version>4.0.1</spark.version>
         <okhttp.version>4.12.0</okhttp.version>
-        <caffeine.version>3.2.2</caffeine.version>
+        <caffeine.version>3.2.3</caffeine.version>
         <junit.jupiter.version>5.13.4</junit.jupiter.version>
-        <mockito.version>5.19.0</mockito.version>
+        <mockito.version>5.20.0</mockito.version>
+        <commons-cli.version>1.11.0</commons-cli.version>
     </properties>
 
     <build>
@@ -113,7 +114,7 @@
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
-            <version>1.10.0</version>
+            <version>${commons-cli.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
-        <caffeine.version>3.2.2</caffeine.version>
+        <caffeine.version>3.2.3</caffeine.version>

-        <mockito.version>5.19.0</mockito.version>
+        <mockito.version>5.20.0</mockito.version>

+        <commons-cli.version>1.11.0</commons-cli.version>