### PR TITLE
Upgrade Docker parent image to Spark 4.1.1 and align Java version to 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM maven:3.9.9-eclipse-temurin-21 AS build
+FROM maven:3.9.12-eclipse-temurin-17 AS build
 COPY src /home/app/src
 COPY pom.xml /home/app
 RUN mvn -B -ntp -Dmaven.test.skip=true -f /home/app/pom.xml clean package
 
-FROM apache/spark:4.0.1-java21
+FROM apache/spark:4.1.1-java17
 COPY --from=build /home/app/target/spruce-*.jar /usr/local/lib/spruce.jar


### PR DESCRIPTION
This PR upgrades the Docker parent image to Apache Spark 4.1.1 and aligns the Maven build stage to Java 17 for consistency with the runtime.

Fixes #120

**Summary**
Updates Docker image/runtime dependency versions (Spark base image + Maven build image) in Dockerfile.

**Why**
Keep dependencies current and aligned with the project’s Spark/Java version targets.

**What changed**
Dockerfile: build stage uses maven:3.9.12-eclipse-temurin-17; runtime uses apache/spark:4.1.1-java17.

**Testing**
Built locally: docker build -t spruce:local .

**Smoke test (no CUR data available):** confirmed /opt/spark/bin/spark-submit and /usr/local/lib/spruce.jar exist, and spark-submit --class com.digitalpebble.spruce.SparkJob ... starts and prints usage (expected without -i/-o).

**Notes / limitations**
I'm having some issues with my AWS acc right now & also I don’t have access to AWS CUR Parquet data to run an end-to-end enrichment job; maintainers can validate with real CUR input using the Docker tutorial **_(docs/src/tutorial/with-docker.md)_**