### PR TITLE
Feature/jacoco coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <junit.jupiter.version>6.0.2</junit.jupiter.version>
         <mockito.version>5.21.0</mockito.version>
         <commons-cli.version>1.11.0</commons-cli.version>
+        <jacoco.version>0.8.11</jacoco.version>
     </properties>
 
     <build>
@@ -77,9 +78,10 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.11</version>
+                <version>${jacoco.version}</version>
                 <executions>
                     <execution>
+                        <id>prepare-agent</id>
                         <goals>
                             <goal>prepare-agent</goal>
                         </goals>
@@ -90,6 +92,26 @@
                         <goals>
                             <goal>report</goal>
                         </goals>
+                    </execution>
+                    <execution>
+                        <id>check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.60</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
This PR adds the JaCoCo Maven plugin to generate code coverage reports during the build process(Fixes #136)

### Changes
* Added `jacoco-maven-plugin` to `pom.xml`.
* Configured execution to automatically generate reports after tests.

### How to test
You can generate the coverage report by running the standard test command in your terminal:

```bash
mvn clean test
```

### Where to check results
Once the build completes successfully, the report is generated in `target` directory.
- Open the file `target/site/jacoco/index.html` in your browser as localhost.
- You will see a breakdown of code coverage per package/class (green bars indicate covered code, red indicates missed branches).