### PR TITLE
Fix ClassCastException when reading MapType product column on Spark 4.x

### DIFF
--- a/src/main/java/com/digitalpebble/spruce/Utils.java
+++ b/src/main/java/com/digitalpebble/spruce/Utils.java
@@ -133,6 +133,39 @@ public abstract class Utils {
     }
 
     /**
+     * Extracts a string value from the {@code product} map column.
+     * Handles both {@code scala.collection.Map} (standard) and {@code Seq<Row>}
+     * (Parquet key-value struct array) representations used by Spark 4.x.
+     *
+     * @param row          the CUR row
+     * @param key          the map key to look up
+     * @param defaultValue value returned when the key is absent or the column is null
+     * @return the value for {@code key}, or {@code defaultValue} if not found
+     */
+    @SuppressWarnings("unchecked")
+    public static String getStringFromProductMap(Row row, String key, String defaultValue) {
+        int index = CURColumn.PRODUCT.resolveIndex(row);
+        if (row.isNullAt(index)) return defaultValue;
+        Object raw = row.get(index);
+        if (raw instanceof scala.collection.Map) {
+            scala.Option<?> opt = ((scala.collection.Map<String, ?>) raw).get(key);
+            return opt.isDefined() ? String.valueOf(opt.get()) : defaultValue;
+        }
+        if (raw instanceof scala.collection.Seq) {
+            scala.collection.Seq<?> seq = (scala.collection.Seq<?>) raw;
+            for (int i = 0; i < seq.size(); i++) {
+                Object elem = seq.apply(i);
+                if (elem instanceof Row kv) {
+                    if (key.equals(kv.get(0))) {
+                        return kv.isNullAt(1) ? defaultValue : kv.getString(1);
+                    }
+                }
+            }
+        }
+        return defaultValue;
+    }
+
+    /**
      * Loads a CSV resource and returns a list of String arrays.
      * Skips lines starting with # or empty lines.
      */

--- a/src/main/java/com/digitalpebble/spruce/modules/Networking.java
+++ b/src/main/java/com/digitalpebble/spruce/modules/Networking.java
@@ -4,6 +4,7 @@ package com.digitalpebble.spruce.modules;
 
 import com.digitalpebble.spruce.Column;
 import com.digitalpebble.spruce.EnrichmentModule;
+import com.digitalpebble.spruce.Utils;
 import org.apache.spark.sql.Row;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,9 +72,7 @@ public class Networking implements EnrichmentModule {
         if (!"AWSDataTransfer".equals(service_code)) {
             return;
         }
-        int index = PRODUCT.resolveIndex(row);
-        Map<Object, Object> productMap = row.getJavaMap(index);
-        String transfer_type = (String) productMap.getOrDefault("transfer_type", "");
+        String transfer_type = Utils.getStringFromProductMap(row, "transfer_type", "");
 
         double network_coefficient = 0d;
 

--- a/src/main/java/com/digitalpebble/spruce/modules/ccf/Networking.java
+++ b/src/main/java/com/digitalpebble/spruce/modules/ccf/Networking.java
@@ -4,6 +4,7 @@ package com.digitalpebble.spruce.modules.ccf;
 
 import com.digitalpebble.spruce.Column;
 import com.digitalpebble.spruce.EnrichmentModule;
+import com.digitalpebble.spruce.Utils;
 import org.apache.spark.sql.Row;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,9 +56,7 @@ public class Networking implements EnrichmentModule {
             return;
         }
         //  apply only to rows corresponding to networking in or out of a region
-        int index = PRODUCT.resolveIndex(row);
-        Map<Object, Object> productMap = row.getJavaMap(index);
-        String transfer_type = (String) productMap.getOrDefault("transfer_type", "");
+        String transfer_type = Utils.getStringFromProductMap(row, "transfer_type", "");
 
         if (!transfer_type.startsWith("InterRegion")) {
             return;

--- a/src/main/java/com/digitalpebble/spruce/modules/ecologits/BedrockEcoLogits.java
+++ b/src/main/java/com/digitalpebble/spruce/modules/ecologits/BedrockEcoLogits.java
@@ -4,6 +4,7 @@ package com.digitalpebble.spruce.modules.ecologits;
 
 import com.digitalpebble.spruce.Column;
 import com.digitalpebble.spruce.EnrichmentModule;
+import com.digitalpebble.spruce.Utils;
 import org.apache.spark.sql.Row;
 
 import java.util.Map;
@@ -61,13 +62,7 @@ public class BedrockEcoLogits implements EnrichmentModule {
             return;
         }
 
-        int productIndex = PRODUCT.resolveIndex(row);
-        Map<Object, Object> productMap = row.getJavaMap(productIndex);
-        if (productMap == null) {
-            return;
-        }
-
-        String modelId = (String) productMap.get("model");
+        String modelId = Utils.getStringFromProductMap(row, "model", null);
         if (modelId == null || modelId.isEmpty()) {
             LOG.warn("BedrockEcoLogits: model key missing or empty in product map");
             return;

--- a/src/test/java/com/digitalpebble/spruce/UtilsGetStringFromProductMapTest.java
+++ b/src/test/java/com/digitalpebble/spruce/UtilsGetStringFromProductMapTest.java
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalpebble.spruce;
+
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+import scala.collection.JavaConverters;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link Utils#getStringFromProductMap(Row, String, String)}.
+ * Verifies both the standard {@code scala.collection.Map} representation
+ * and the {@code Seq<Row>} (Parquet key-value array) representation
+ * that Spark 4.x may produce for MapType columns.
+ */
+public class UtilsGetStringFromProductMapTest {
+
+    private static final StructType SCHEMA = new StructType(new StructField[]{
+            StructField.apply("product",
+                    DataTypes.createMapType(DataTypes.StringType, DataTypes.StringType),
+                    true, null)
+    });
+
+    /** Build a row whose product column holds a scala.collection.Map. */
+    private static Row rowWithScalaMap(Map<String, String> map) {
+        Object scalaMap = map != null ? JavaConverters.mapAsScalaMapConverter(map).asScala() : null;
+        return new GenericRowWithSchema(new Object[]{scalaMap}, SCHEMA);
+    }
+
+    /** Build a row whose product column holds an ArraySeq of key-value Rows (Parquet representation). */
+    private static Row rowWithSeq(String[][] entries) {
+        if (entries == null) {
+            return new GenericRowWithSchema(new Object[]{null}, SCHEMA);
+        }
+        Row[] rows = new Row[entries.length];
+        for (int i = 0; i < entries.length; i++) {
+            rows[i] = RowFactory.create(entries[i][0], entries[i][1]);
+        }
+        scala.collection.Seq<Row> seq = scala.collection.mutable.ArraySeq.make(rows);
+        return new GenericRowWithSchema(new Object[]{seq}, SCHEMA);
+    }
+
+    // --- scala.collection.Map tests ---
+
+    @Test
+    void scalaMap_returnsValue() {
+        Row row = rowWithScalaMap(Map.of("model", "claude-v2", "region", "us-east-1"));
+        assertEquals("claude-v2", Utils.getStringFromProductMap(row, "model", null));
+        assertEquals("us-east-1", Utils.getStringFromProductMap(row, "region", null));
+    }
+
+    @Test
+    void scalaMap_missingKeyReturnsDefault() {
+        Row row = rowWithScalaMap(Map.of("model", "claude-v2"));
+        assertNull(Utils.getStringFromProductMap(row, "missing", null));
+        assertEquals("fallback", Utils.getStringFromProductMap(row, "missing", "fallback"));
+    }
+
+    @Test
+    void scalaMap_emptyMapReturnsDefault() {
+        Row row = rowWithScalaMap(Map.of());
+        assertEquals("def", Utils.getStringFromProductMap(row, "model", "def"));
+    }
+
+    // --- Seq<Row> (Parquet array) tests ---
+
+    @Test
+    void seq_returnsValue() {
+        Row row = rowWithSeq(new String[][]{{"model", "claude-v2"}, {"region", "us-east-1"}});
+        assertEquals("claude-v2", Utils.getStringFromProductMap(row, "model", null));
+        assertEquals("us-east-1", Utils.getStringFromProductMap(row, "region", null));
+    }
+
+    @Test
+    void seq_missingKeyReturnsDefault() {
+        Row row = rowWithSeq(new String[][]{{"model", "claude-v2"}});
+        assertNull(Utils.getStringFromProductMap(row, "missing", null));
+        assertEquals("fallback", Utils.getStringFromProductMap(row, "missing", "fallback"));
+    }
+
+    @Test
+    void seq_emptySeqReturnsDefault() {
+        Row row = rowWithSeq(new String[][]{});
+        assertEquals("def", Utils.getStringFromProductMap(row, "model", "def"));
+    }
+
+    // --- null column tests ---
+
+    @Test
+    void nullColumn_returnsDefault() {
+        Row row = rowWithScalaMap(null);
+        assertNull(Utils.getStringFromProductMap(row, "model", null));
+        assertEquals("def", Utils.getStringFromProductMap(row, "model", "def"));
+    }
+}


### PR DESCRIPTION
Spark 4.x Parquet reader may represent MapType columns as a Seq of key-value Rows instead of a scala.collection.Map, causing Row.getJavaMap() to throw a ClassCastException. Replace all getJavaMap() calls on the product column with a shared Utils.getStringFromProductMap() helper that handles both representations.