### PR TITLE
Specify entrypoint to simplify the use of the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,3 +5,4 @@ RUN mvn -B -ntp -Dmaven.test.skip=true -f /home/app/pom.xml clean package
 
 FROM apache/spark:4.1.1-java17
 COPY --from=build /home/app/target/spruce-*.jar /usr/local/lib/spruce.jar
+ENTRYPOINT ["/opt/spark/bin/spark-submit", "--driver-memory", "4g", "--master", "local[*]", "/usr/local/lib/spruce.jar"]


### PR DESCRIPTION
This allows to rely on default configuration and minimise the amount of input a user has to provide

```shell  
docker run --rm -v $(pwd):/workspace -w /workspace \    
   ghcr.io/digitalpebble/spruce \
   -i curs -o output
```

It is still possible to provide the full command line with `entrypoint`

```shell                                                                                                                                                                                                                     
 docker run --rm -v $(pwd):/workspace -w /workspace \                                                                                                                                                                         
 --entrypoint /opt/spark/bin/spark-submit \                                                                                                                                                                                   
 ghcr.io/digitalpebble/spruce \                                                                                                                                                                                               
 --driver-memory 8g \                                                                                                                                                                                                         
 --master 'local[*]' \                                                                                                                                                                                                        
 /usr/local/lib/spruce.jar \                                                                                                                                                                                                  
 -i curs -o output                                                                                                                                                                                                   
```                        