### PR TITLE
configure versioning for documentation site

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,8 +3,8 @@ on:
   push:
     branches:
       - main
-    tags:
-      - '*.*'
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:
@@ -32,9 +32,9 @@ jobs:
       - name: Deploy dev version from main
         if: github.ref == 'refs/heads/main'
         run: cd docs && mike deploy --push --update-aliases dev
-      - name: Deploy released version from tag
-        if: github.ref_type == 'tag'
+      - name: Deploy released version from release tag
+        if: github.event_name == 'release' && !github.event.release.prerelease
         run: |
           cd docs
-          mike deploy --push --update-aliases "${GITHUB_REF_NAME}" latest
+          mike deploy --push --update-aliases "${{ github.event.release.tag_name }}" latest
           mike set-default --push latest

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,31 +3,38 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'docs/**'
-      - '.github/workflows/documentation.yml'
+    tags:
+      - '*.*'
+  workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
+
+concurrency:
+  group: gh-pages
+  cancel-in-progress: false
 
 jobs:
   deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/configure-pages@v6
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v6
         with:
           python-version: 3.x
-      - run: pip install zensical
-      - run: cd docs && zensical build --clean
-      - uses: actions/upload-pages-artifact@v5
-        with:
-          path: docs/site
-      - uses: actions/deploy-pages@v5
-        id: deployment
+      - run: pip install zensical "mike @ git+https://github.com/squidfunk/mike.git"
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Deploy dev version from main
+        if: github.ref == 'refs/heads/main'
+        run: cd docs && mike deploy --push --update-aliases dev
+      - name: Deploy released version from tag
+        if: github.ref_type == 'tag'
+        run: |
+          cd docs
+          mike deploy --push --update-aliases "${GITHUB_REF_NAME}" latest
+          mike set-default --push latest

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,18 @@
 source .venv/bin/activate
 zensical serve
 
+## Versioned docs
+
+Versioning uses [mike](https://github.com/squidfunk/mike) (Zensical fork). Install it with:
+
+    pip install "mike @ git+https://github.com/squidfunk/mike.git"
+
+Preview the versioned site (with the version selector) locally:
+
+    mike serve
+
+Releases are published automatically by `.github/workflows/documentation.yml`: pushes to `main` update the `dev` alias, and release tags publish a numbered version aliased to `latest`.
+
 https://zensical.org/docs/setup/versioning/
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ Preview the versioned site (with the version selector) locally:
 
     mike serve
 
-Releases are published automatically by `.github/workflows/documentation.yml`: pushes to `main` update the `dev` alias, and release tags publish a numbered version aliased to `latest`.
+Releases are published automatically by `.github/workflows/documentation.yml`: pushes to `main` update the `dev` alias, and publishing a GitHub release publishes a numbered version (the release tag) aliased to `latest`.
 
 https://zensical.org/docs/setup/versioning/
 

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -95,6 +95,8 @@ docs_dir = "src"
 
 [project.extra.version]
 provider = "mike"
+default = "latest"
+alias = true
 
 # ----------------------------------------------------------------------------
 # Section for configuring theme options


### PR DESCRIPTION
- Closes #227 

Enable versioned docs using mike (Zensical fork):
- zensical.toml: add default="latest" and alias=true
- documentation.yml: switch from Pages artifact to gh-pages push;
main builds the dev alias, release tags publish a numbered version
aliased to latest and set the default redirect
- add concurrency guard and fetch-depth: 0 for mike's gh-pages push
- README: local versioned-preview instructions

Requires switching the GitHub Pages source to the gh-pages branch
  (repo Settings -> Pages) for the first deploy to publish.
