### PR TITLE
only rebuild docs site on docs-related changes

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'docs/**'
+      - '.github/workflows/documentation.yml'
   release:
     types: [published]
   workflow_dispatch:


### PR DESCRIPTION
Add a paths filter to the push trigger so the documentation workflow runs only when docs/, zensical.toml, or the workflow itself change. Code-only commits to main no longer trigger a redundant docs rebuild.

Release and workflow_dispatch events ignore the paths filter and still run unconditionally.