### PR TITLE
Use FOCUS columns in reporting scripts and dashboard

### DIFF
--- a/docs/src/howto/dashboard.md
+++ b/docs/src/howto/dashboard.md
@@ -3,7 +3,9 @@
 The repository includes `reporting/dashboard.py`, a [Streamlit](https://streamlit.io/)
 example that reads SPRUCE-enriched Parquet output and runs interactive DuckDB
 queries locally to explore cost, energy, emissions, water, region, and tag
-breakdowns.
+breakdowns. Like `report.py`, it queries the FOCUS columns emitted by all
+SPRUCE pipelines, so it works on the enriched output of every supported input
+format (AWS CUR, AWS FOCUS, Azure cost details, Azure FOCUS).
 
 ## Install
 
@@ -49,11 +51,11 @@ python scripts/gen_synthetic.py -o output/synth.parquet --force
 |---|---|
 | Overview | Total usage cost, energy, operational emissions, embodied emissions, water usage, and cost coverage for the full input, plus everyday equivalences (car km, flights, home-years, cups of tea, pools, baths) |
 | Trend | Separate energy, total emissions, and water charts by billing period |
-| Top emitters | Sorted top product/service/operation combinations as a table-first view |
+| Top emitters | Sorted top service/region combinations as a table-first view |
 | Regions | Emissions share by region, plus regional KPI cards and detail table |
-| Tags | Sorted tag-value chart and table for a selected `resource_tags` key |
+| Tags | Sorted tag-value chart and table for a selected `Tags` key |
 
-Use the sidebar to filter by billing period and region. If `resource_tags` are
+Use the sidebar to filter by billing period and region. If `Tags` are
 present, choose one tag key to break down emissions by tag value. The cost
 coverage KPI matches `report.py` and is calculated across the full input, not
 only the currently selected filters.

--- a/docs/src/tutorial/results.md
+++ b/docs/src/tutorial/results.md
@@ -8,7 +8,7 @@ reads the same inputs as `report.py` and runs DuckDB queries locally.
 
 ## Automated report
 
-The easiest way to explore SPRUCE output is `report.py`, a Python script that reads enriched Parquet files, runs all the analyses described on this page automatically, and writes a formatted report — no SQL required.
+The easiest way to explore SPRUCE output is `report.py`, a Python script that reads enriched Parquet files, runs all the analyses described on this page automatically, and writes a formatted report — no SQL required. Its queries use the FOCUS columns emitted by all SPRUCE pipelines, so it works on the enriched output of every supported input format (AWS CUR, AWS FOCUS, Azure cost details, Azure FOCUS). If the input is not partitioned by `BILLING_PERIOD`, the billing periods are inferred from the FOCUS `ChargePeriodStart` column.
 
 ### Installation
 
@@ -44,14 +44,14 @@ The report covers the following sections, drawn from the queries documented belo
 | Section | What it shows                                                                                                |
 |---|--------------------------------------------------------------------------------------------------------------|
 | Summary by Billing Period | Energy (kWh), operational CO₂ (kg), embodied CO₂ (kg), water usage (l)                                       |
-| Top Emitters by Service | Top 20 product/service/operation combinations by operational CO₂                                             |
-| Top Instance Types | Top 20 instance families by operational + embodied CO₂                                                       |
-| Coverage | % of unblended costs that have emissions data; top 20 uncovered services by cost                             |
-| Regional Analysis | CO₂, energy, carbon intensity, water, PUE, and gCO₂/$ per AWS region                                         |
+| Top Emitters by Service | Top 20 services by operational CO₂                                                                           |
+| Top Instance Types | Top 20 instance families by operational + embodied CO₂ (derived from `SkuMeter`, where populated)            |
+| Coverage | % of billed costs that have emissions data; top 20 uncovered services by cost                                |
+| Regional Analysis | CO₂, energy, carbon intensity, water, PUE, and gCO₂/$ per region                                             |
 | Tag Breakdown | Interactive: emissions split by any resource tag present in the data                                         |
 | Recommendations | Automatically generated from coverage gaps, regional carbon intensity, instance families, and billing trends |
 
-After the fixed sections, the script scans `resource_tags` and presents an interactive menu of the most consistently used tag keys, ordered by the percentage of line items that carry a non-empty value. Select a tag to see the emissions breakdown by tag value; press Enter when done. If no tags are found, the report states this clearly.
+After the fixed sections, the script scans the `Tags` column and presents an interactive menu of the most consistently used tag keys, ordered by the percentage of line items that carry a non-empty value. Select a tag to see the emissions breakdown by tag value; press Enter when done. If no tags are found, the report states this clearly.
 
 Recommendations are generated automatically from the data:
 
@@ -65,7 +65,9 @@ Recommendations are generated automatically from the data:
 ## Manual queries
 
 As an alternative to the script above, you can also write equivalent SQL queries using [DuckDB](https://duckdb.org/) locally
- (or [Athena](https://docs.aws.amazon.com/athena/latest/ug/what-is.html) if the output was [written to S3](../howto/s3.md)):
+ (or [Athena](https://docs.aws.amazon.com/athena/latest/ug/what-is.html) if the output was [written to S3](../howto/s3.md)).
+The examples below use the native AWS CUR columns, which pass through into the enriched output alongside the FOCUS ones;
+on the output of another pipeline, substitute the corresponding provider or FOCUS columns (e.g. `ServiceName`, `BilledCost`):
 
 ### Breakdown by billing period
 

--- a/reporting/README.md
+++ b/reporting/README.md
@@ -1,6 +1,6 @@
 # SPRUCE Reporting Tools
 
-This directory contains Python scripts for generating reports and interactive dashboards from SPRUCE-enriched AWS Cost & Usage Report (CUR) data.
+This directory contains Python scripts for generating reports and interactive dashboards from SPRUCE-enriched billing data. The queries use the [FOCUS](https://focus.finops.org/) (FinOps Open Cost & Usage Specification) columns emitted by all SPRUCE pipelines, so the same tools work on the output of every supported input format (AWS CUR, AWS FOCUS, Azure cost details, Azure FOCUS).
 
 ## Prerequisites
 
@@ -18,7 +18,9 @@ pip install -r reporting/requirements-dashboard.txt
 
 Both tools expect SPRUCE-enriched Parquet files as input. These files contain:
 
-- Original AWS CUR columns (cost, usage, resource metadata)
+- The original provider columns (cost, usage, resource metadata)
+- FOCUS columns, present natively in FOCUS exports and added by the
+  `FOCUSColumns` bridge modules for native exports
 - SPRUCE-added sustainability metrics:
   - `operational_energy_kwh` - Energy consumption
   - `operational_emissions_co2eq_g` - Operational carbon emissions
@@ -32,28 +34,28 @@ Both tools expect SPRUCE-enriched Parquet files as input. These files contain:
 
 ## Report Generator
 
-Generate a static HTML report with summary statistics and visualizations:
+Generate a static report with summary statistics and recommendations:
 
 ```bash
-python3 reporting/report.py --input path/to/enriched.parquet --output report.html
+python3 reporting/report.py --input path/to/enriched/ --output report.md
 ```
 
 ### Options
 
-- `--input`: Path to enriched Parquet file or directory (supports glob patterns)
-- `--output`: Output HTML file path (default: `report.html`)
-- `--title`: Report title (default: "SPRUCE Report")
-- `--period`: Filter by billing period (e.g., "2024-01")
-- `--region`: Filter by region (e.g., "us-east-1")
+- `-i / --input`: Path to enriched Parquet file, directory, glob pattern, or S3 URI (required)
+- `-o / --output`: Output file; format inferred from the suffix (`.md`, `.html`, `.pdf`); defaults to Markdown on stdout
+- `-t / --top-tags`: Maximum number of resource tags offered for interactive breakdown (default 10; 0 disables)
 
 ### Output
 
 The generated report includes:
-- Summary metrics (total cost, emissions, energy, water)
-- Time series charts for emissions, energy, and water usage
-- Top emitters breakdown
+- Summary by billing period (energy, emissions, water) with everyday equivalences
+- Top emitters by service
+- Top instance types (derived from `SkuMeter`, where populated)
+- Coverage (% of billed costs with emissions data, top uncovered services)
 - Regional analysis
-- Service breakdown
+- Interactive tag breakdowns
+- Recommendations generated from the data
 
 ## Interactive Dashboard
 
@@ -67,9 +69,9 @@ streamlit run reporting/dashboard.py -- --input path/to/enriched/
 
 - **Overview**: Summary metrics and coverage statistics
 - **Trend**: Time series visualization of emissions, energy, and water usage
-- **Top Emitters**: Breakdown of highest-emitting services and resources
+- **Top Emitters**: Breakdown of highest-emitting services per region
 - **Regions**: Regional analysis with emissions distribution
-- **Tags**: Resource tag-based breakdowns (when `resource_tags` column is available)
+- **Tags**: Resource tag-based breakdowns (when the `Tags` column is available)
 
 ### Navigation
 
@@ -92,20 +94,19 @@ Requires AWS credentials configured in your environment.
 
 ## Data Requirements
 
-### Required Columns
+### Columns Used
 
-The tools expect these columns to be present in the enriched data:
+The queries rely on standard FOCUS columns and SPRUCE-generated columns only
+(no provider-specific `x_` columns):
 
 ```
 BILLING_PERIOD
 region
-product_region_code
-line_item_product_code
-product_servicecode
-line_item_operation
-line_item_line_item_type
-line_item_unblended_cost
-pricing_public_on_demand_cost
+ServiceName
+ChargeCategory
+BilledCost
+ListCost
+SkuMeter
 operational_energy_kwh
 operational_emissions_co2eq_g
 embodied_emissions_co2eq_g
@@ -116,11 +117,18 @@ carbon_intensity
 power_usage_effectiveness
 ```
 
+Any of these columns missing from the input is added as a typed NULL, so the
+same queries run on the output of every pipeline — the corresponding report
+sections simply come out empty. When the input is not hive-partitioned by
+`BILLING_PERIOD`, the YYYY-MM billing periods are inferred from the FOCUS
+`ChargePeriodStart` column.
+
 ### Optional Columns
 
-- `resource_tags`: MAP<VARCHAR,VARCHAR> column for tag-based breakdowns
+- `Tags`: resource tags for tag-based breakdowns. AWS outputs carry it as a
+  `MAP<VARCHAR,VARCHAR>`, Azure ones as a JSON string; both are supported.
 
-If `resource_tags` is not present, the Tags tab will not be displayed in the dashboard.
+If `Tags` is not present, the Tags tab will not be displayed in the dashboard.
 
 ## Output Format
 

--- a/reporting/dashboard.py
+++ b/reporting/dashboard.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 """
-Interactive dashboard for SPRUCE-enriched CUR output.
+Interactive dashboard for SPRUCE-enriched output.
+
+Queries use the FOCUS (FinOps Open Cost & Usage Specification) columns emitted
+by all SPRUCE pipelines (AWS CUR, AWS FOCUS, Azure, Azure FOCUS); columns a
+given input does not carry are added as NULLs so every query runs everywhere.
 
 Run with:
     streamlit run reporting/dashboard.py -- --input output/
@@ -67,16 +71,17 @@ QUERY_CACHE_TTL_SECONDS = 300
 CONNECTION_CACHE_MAX_ENTRIES = 2
 PLOT_CONFIG = {"displaylogo": False, "scrollZoom": True}
 
+# Columns the queries below rely on. Any of them missing from the input is
+# added as a typed NULL so the same queries run on the output of every
+# pipeline. Tags is handled separately as its type differs per provider
+# (MAP on AWS, JSON string on Azure).
 DASHBOARD_COLUMN_DEFAULTS = MappingProxyType(
     {
         "BILLING_PERIOD": "VARCHAR",
         "region": "VARCHAR",
-        "line_item_product_code": "VARCHAR",
-        "product_servicecode": "VARCHAR",
-        "line_item_operation": "VARCHAR",
-        "line_item_line_item_type": "VARCHAR",
-        "line_item_unblended_cost": "DOUBLE",
-        "pricing_public_on_demand_cost": "DOUBLE",
+        "ServiceName": "VARCHAR",
+        "ChargeCategory": "VARCHAR",
+        "BilledCost": "DOUBLE",
         "operational_energy_kwh": "DOUBLE",
         "operational_emissions_co2eq_g": "DOUBLE",
         "embodied_emissions_co2eq_g": "DOUBLE",
@@ -165,15 +170,47 @@ def parquet_source_sql(parquet_path: str) -> str:
     return f"read_parquet({sql_literal(parquet_path)}, hive_partitioning=true)"
 
 
+# When the input is not hive-partitioned by BILLING_PERIOD, the YYYY-MM split
+# is inferred from the FOCUS ChargePeriodStart column, which pipelines emit as
+# a timestamp, an ISO 8601 string, or a US-style date string.
+BILLING_PERIOD_FROM_CHARGE_PERIOD = r"""
+    CASE WHEN regexp_matches(CAST(ChargePeriodStart AS VARCHAR), '^\d{4}-\d{2}')
+         THEN substr(CAST(ChargePeriodStart AS VARCHAR), 1, 7)
+         ELSE strftime(coalesce(
+                  try_strptime(CAST(ChargePeriodStart AS VARCHAR), '%m/%d/%Y'),
+                  try_strptime(CAST(ChargePeriodStart AS VARCHAR), '%-m/%-d/%Y')),
+              '%Y-%m')
+    END
+""".strip()
+
+
 def create_dashboard_view(con: duckdb.DuckDBPyConnection, parquet_path: str) -> None:
     source_sql = parquet_source_sql(parquet_path)
     schema_rows = con.execute(f"DESCRIBE SELECT * FROM {source_sql}").fetchall()
     existing_columns = [str(row[0]) for row in schema_rows]
-    existing_set = set(existing_columns)
+    existing_lower = {column.lower() for column in existing_columns}
 
-    select_exprs = [sql_identifier(column) for column in existing_columns]
+    # Inputs may carry a known column under a different case (e.g. a
+    # billing_period parquet column instead of the BILLING_PERIOD hive
+    # partition); alias it so pandas lookups on the canonical name work.
+    canonical = {name.lower(): name for name in DASHBOARD_COLUMN_DEFAULTS}
+    select_exprs = []
+    for column in existing_columns:
+        wanted = canonical.get(column.lower())
+        if wanted is not None and wanted != column:
+            select_exprs.append(
+                f"{sql_identifier(column)} AS {sql_identifier(wanted)}"
+            )
+        else:
+            select_exprs.append(sql_identifier(column))
     for column_name, column_type in DASHBOARD_COLUMN_DEFAULTS.items():
-        if column_name not in existing_set:
+        if column_name.lower() in existing_lower:
+            continue
+        if column_name == "BILLING_PERIOD" and "chargeperiodstart" in existing_lower:
+            select_exprs.append(
+                f"{BILLING_PERIOD_FROM_CHARGE_PERIOD} AS {sql_identifier(column_name)}"
+            )
+        else:
             select_exprs.append(
                 f"CAST(NULL AS {column_type}) AS {sql_identifier(column_name)}"
             )
@@ -228,23 +265,46 @@ def get_filter_options(input_path: str) -> tuple[list[str], list[str]]:
 
 
 @st.cache_data(show_spinner=False, ttl=QUERY_CACHE_TTL_SECONDS)
+def tags_column_kind(input_path: str) -> str | None:
+    """Return 'map' or 'json' depending on how the Tags column is stored
+    (MAP on AWS outputs, JSON string on Azure ones), or None when the input
+    has no Tags column."""
+    con = load_connection(input_path)
+    row = con.execute(
+        "SELECT column_type FROM (DESCRIBE cur) WHERE lower(column_name) = 'tags'"
+    ).fetchone()
+    if row is None:
+        return None
+    return "map" if str(row[0]).upper().startswith("MAP") else "json"
+
+
+def tag_value_sql_and_param(kind: str, tag_key: str) -> tuple[str, str]:
+    """SQL expression extracting the value of one tag from Tags, plus the
+    bind parameter to pass for each ? placeholder it contains."""
+    if kind == "map":
+        return "Tags[?]", tag_key
+    return (
+        "json_extract_string(TRY_CAST(Tags AS JSON), ?)",
+        '$."' + tag_key.replace('"', '\\"') + '"',
+    )
+
+
+@st.cache_data(show_spinner=False, ttl=QUERY_CACHE_TTL_SECONDS)
 def get_tag_keys(input_path: str) -> list[str]:
+    kind = tags_column_kind(input_path)
+    if kind is None:
+        return []
+    keys_expr = (
+        "map_keys(Tags)" if kind == "map" else "json_keys(TRY_CAST(Tags AS JSON))"
+    )
     try:
-        # Check if resource_tags column exists first
-        con = load_connection(input_path)
-        columns = con.execute("SELECT column_name FROM information_schema.columns WHERE table_name = 'cur'").fetchall()
-        column_names = [str(row[0]) for row in columns]
-        
-        if 'resource_tags' not in column_names:
-            return []
-        
         return (
             query_df(
                 input_path,
-                """
-            SELECT DISTINCT unnest(map_keys(resource_tags)) AS tag_key
+                f"""
+            SELECT DISTINCT unnest({keys_expr}) AS tag_key
             FROM cur
-            WHERE resource_tags IS NOT NULL
+            WHERE Tags IS NOT NULL
             ORDER BY tag_key
             """,
             )["tag_key"]
@@ -252,7 +312,7 @@ def get_tag_keys(input_path: str) -> list[str]:
             .astype(str)
             .tolist()
         )
-    except duckdb.Error as exc:
+    except duckdb.Error:
         return []
 
 
@@ -265,32 +325,32 @@ def overview_query(where: str) -> str:
         ), filtered_agg AS (
             SELECT
                 count(*) AS row_count,
-                sum(line_item_unblended_cost)
-                    FILTER (WHERE line_item_line_item_type LIKE '%Usage') AS total_cost,
+                sum(BilledCost)
+                    FILTER (WHERE ChargeCategory LIKE '%Usage') AS total_cost,
                 sum(operational_energy_kwh)
-                    FILTER (WHERE line_item_line_item_type LIKE '%Usage') AS energy_kwh,
+                    FILTER (WHERE ChargeCategory LIKE '%Usage') AS energy_kwh,
                 sum(operational_emissions_co2eq_g)
-                    FILTER (WHERE line_item_line_item_type LIKE '%Usage') AS operational_g,
+                    FILTER (WHERE ChargeCategory LIKE '%Usage') AS operational_g,
                 sum(embodied_emissions_co2eq_g)
-                    FILTER (WHERE line_item_line_item_type LIKE '%Usage') AS embodied_g,
+                    FILTER (WHERE ChargeCategory LIKE '%Usage') AS embodied_g,
                 coalesce(
                     sum(water_cooling_l)
-                        FILTER (WHERE line_item_line_item_type LIKE '%Usage'),
+                        FILTER (WHERE ChargeCategory LIKE '%Usage'),
                     0
                 )
                 + coalesce(
                     sum(water_electricity_production_l)
-                        FILTER (WHERE line_item_line_item_type LIKE '%Usage'),
+                        FILTER (WHERE ChargeCategory LIKE '%Usage'),
                     0
                 ) AS water_l
             FROM filtered
         ), coverage AS (
             SELECT
-                sum(line_item_unblended_cost)
-                    FILTER (WHERE line_item_line_item_type LIKE '%Usage') AS usage_cost,
-                sum(line_item_unblended_cost)
+                sum(BilledCost)
+                    FILTER (WHERE ChargeCategory LIKE '%Usage') AS usage_cost,
+                sum(BilledCost)
                     FILTER (
-                        WHERE line_item_line_item_type LIKE '%Usage'
+                        WHERE ChargeCategory LIKE '%Usage'
                           AND operational_emissions_co2eq_g IS NOT NULL
                     ) AS covered_cost
             FROM cur
@@ -318,35 +378,35 @@ def billing_query(where: str) -> str:
         SELECT
             BILLING_PERIOD,
             round(
-                sum(line_item_unblended_cost)
-                    FILTER (WHERE line_item_line_item_type LIKE '%Usage'),
+                sum(BilledCost)
+                    FILTER (WHERE ChargeCategory LIKE '%Usage'),
                 2
             ) AS total_cost,
             round(
                 sum(operational_energy_kwh)
-                    FILTER (WHERE line_item_line_item_type LIKE '%Usage'),
+                    FILTER (WHERE ChargeCategory LIKE '%Usage'),
                 2
             ) AS energy_kwh,
             round(
                 sum(operational_emissions_co2eq_g)
-                    FILTER (WHERE line_item_line_item_type LIKE '%Usage') / 1000,
+                    FILTER (WHERE ChargeCategory LIKE '%Usage') / 1000,
                 2
             ) AS operational_kg,
             round(
                 sum(embodied_emissions_co2eq_g)
-                    FILTER (WHERE line_item_line_item_type LIKE '%Usage') / 1000,
+                    FILTER (WHERE ChargeCategory LIKE '%Usage') / 1000,
                 2
             ) AS embodied_kg,
             round(
                 (
                     coalesce(
                         sum(operational_emissions_co2eq_g)
-                            FILTER (WHERE line_item_line_item_type LIKE '%Usage'),
+                            FILTER (WHERE ChargeCategory LIKE '%Usage'),
                         0
                     )
                     + coalesce(
                         sum(embodied_emissions_co2eq_g)
-                            FILTER (WHERE line_item_line_item_type LIKE '%Usage'),
+                            FILTER (WHERE ChargeCategory LIKE '%Usage'),
                         0
                     )
                 ) / 1000,
@@ -355,12 +415,12 @@ def billing_query(where: str) -> str:
             round(
                 coalesce(
                     sum(water_cooling_l)
-                        FILTER (WHERE line_item_line_item_type LIKE '%Usage'),
+                        FILTER (WHERE ChargeCategory LIKE '%Usage'),
                     0
                 )
                 + coalesce(
                     sum(water_electricity_production_l)
-                        FILTER (WHERE line_item_line_item_type LIKE '%Usage'),
+                        FILTER (WHERE ChargeCategory LIKE '%Usage'),
                     0
                 ),
                 2
@@ -377,38 +437,33 @@ def top_emitters_query(where: str) -> str:
             SELECT *, {REGION_EXPR} AS dashboard_region FROM cur {where}
         )
         SELECT
-            coalesce(nullif(line_item_product_code, ''), 'Unknown product')
-                AS line_item_product_code,
-            coalesce(nullif(product_servicecode, ''), 'Unknown service')
-                AS product_servicecode,
-            coalesce(nullif(line_item_operation, ''), 'Unknown operation')
-                AS line_item_operation,
+            coalesce(nullif(ServiceName, ''), 'Unknown service') AS service_name,
             coalesce(nullif(dashboard_region, ''), 'Unknown region') AS region,
             round(
-                sum(line_item_unblended_cost)
-                    FILTER (WHERE line_item_line_item_type LIKE '%Usage'),
+                sum(BilledCost)
+                    FILTER (WHERE ChargeCategory LIKE '%Usage'),
                 2
             ) AS total_cost,
             round(
                 sum(operational_emissions_co2eq_g)
-                    FILTER (WHERE line_item_line_item_type LIKE '%Usage') / 1000,
+                    FILTER (WHERE ChargeCategory LIKE '%Usage') / 1000,
                 2
             ) AS co2_usage_kg,
             round(
                 sum(embodied_emissions_co2eq_g)
-                    FILTER (WHERE line_item_line_item_type LIKE '%Usage') / 1000,
+                    FILTER (WHERE ChargeCategory LIKE '%Usage') / 1000,
                 2
             ) AS co2_embodied_kg,
             round(
                 (
                     coalesce(
                         sum(operational_emissions_co2eq_g)
-                            FILTER (WHERE line_item_line_item_type LIKE '%Usage'),
+                            FILTER (WHERE ChargeCategory LIKE '%Usage'),
                         0
                     )
                     + coalesce(
                         sum(embodied_emissions_co2eq_g)
-                            FILTER (WHERE line_item_line_item_type LIKE '%Usage'),
+                            FILTER (WHERE ChargeCategory LIKE '%Usage'),
                         0
                     )
                 ) / 1000,
@@ -416,25 +471,25 @@ def top_emitters_query(where: str) -> str:
             ) AS total_emissions_kg,
             round(
                 sum(operational_energy_kwh)
-                    FILTER (WHERE line_item_line_item_type LIKE '%Usage'),
+                    FILTER (WHERE ChargeCategory LIKE '%Usage'),
                 2
             ) AS energy_kwh,
             round(
                 coalesce(
                     sum(water_cooling_l)
-                        FILTER (WHERE line_item_line_item_type LIKE '%Usage'),
+                        FILTER (WHERE ChargeCategory LIKE '%Usage'),
                     0
                 )
                 + coalesce(
                     sum(water_electricity_production_l)
-                        FILTER (WHERE line_item_line_item_type LIKE '%Usage'),
+                        FILTER (WHERE ChargeCategory LIKE '%Usage'),
                     0
                 ),
                 2
             ) AS water_usage_l
         FROM filtered
         WHERE operational_emissions_co2eq_g IS NOT NULL
-        GROUP BY 1, 2, 3, 4
+        GROUP BY 1, 2
         ORDER BY total_emissions_kg DESC, co2_usage_kg DESC, energy_kwh DESC
         LIMIT ?
     """
@@ -448,42 +503,42 @@ def regional_query(where: str) -> str:
             SELECT
                 coalesce(nullif(dashboard_region, ''), 'Unknown region') AS region,
                 sum(operational_emissions_co2eq_g)
-                    FILTER (WHERE line_item_line_item_type LIKE '%Usage') AS operational_g,
+                    FILTER (WHERE ChargeCategory LIKE '%Usage') AS operational_g,
                 sum(embodied_emissions_co2eq_g)
-                    FILTER (WHERE line_item_line_item_type LIKE '%Usage') AS embodied_g,
+                    FILTER (WHERE ChargeCategory LIKE '%Usage') AS embodied_g,
                 sum(operational_energy_kwh)
-                    FILTER (WHERE line_item_line_item_type LIKE '%Usage') AS energy_kwh,
-                sum(line_item_unblended_cost)
-                    FILTER (WHERE line_item_line_item_type LIKE '%Usage') AS usage_cost,
+                    FILTER (WHERE ChargeCategory LIKE '%Usage') AS energy_kwh,
+                sum(BilledCost)
+                    FILTER (WHERE ChargeCategory LIKE '%Usage') AS usage_cost,
                 sum(operational_energy_kwh * carbon_intensity)
-                    FILTER (WHERE line_item_line_item_type LIKE '%Usage'
+                    FILTER (WHERE ChargeCategory LIKE '%Usage'
                               AND operational_energy_kwh IS NOT NULL
                               AND carbon_intensity IS NOT NULL) AS ci_weighted_num,
                 sum(operational_energy_kwh)
-                    FILTER (WHERE line_item_line_item_type LIKE '%Usage'
+                    FILTER (WHERE ChargeCategory LIKE '%Usage'
                               AND operational_energy_kwh IS NOT NULL
                               AND carbon_intensity IS NOT NULL) AS ci_weighted_den,
                 sum(operational_energy_kwh * power_usage_effectiveness)
-                    FILTER (WHERE line_item_line_item_type LIKE '%Usage'
+                    FILTER (WHERE ChargeCategory LIKE '%Usage'
                               AND operational_energy_kwh IS NOT NULL
                               AND power_usage_effectiveness IS NOT NULL) AS pue_weighted_num,
                 sum(operational_energy_kwh)
-                    FILTER (WHERE line_item_line_item_type LIKE '%Usage'
+                    FILTER (WHERE ChargeCategory LIKE '%Usage'
                               AND operational_energy_kwh IS NOT NULL
                               AND power_usage_effectiveness IS NOT NULL) AS pue_weighted_den,
                 coalesce(
                     sum(water_cooling_l)
-                        FILTER (WHERE line_item_line_item_type LIKE '%Usage'),
+                        FILTER (WHERE ChargeCategory LIKE '%Usage'),
                     0
                 )
                 + coalesce(
                     sum(water_electricity_production_l)
-                        FILTER (WHERE line_item_line_item_type LIKE '%Usage'),
+                        FILTER (WHERE ChargeCategory LIKE '%Usage'),
                     0
                 ) AS water_l,
                 coalesce(
                     sum(water_consumption_stress_area_l)
-                        FILTER (WHERE line_item_line_item_type LIKE '%Usage'),
+                        FILTER (WHERE ChargeCategory LIKE '%Usage'),
                     0
                 ) AS water_stress_l
             FROM filtered
@@ -512,43 +567,43 @@ def regional_query(where: str) -> str:
     """
 
 
-def tag_breakdown_query(where: str) -> str:
+def tag_breakdown_query(where: str, tag_value_sql: str) -> str:
     return f"""
         WITH filtered AS (
             SELECT * FROM cur {where}
         )
         SELECT
-            resource_tags[?] AS tag_value,
+            {tag_value_sql} AS tag_value,
             round(
-                sum(line_item_unblended_cost)
-                    FILTER (WHERE line_item_line_item_type LIKE '%Usage'),
+                sum(BilledCost)
+                    FILTER (WHERE ChargeCategory LIKE '%Usage'),
                 2
             ) AS total_cost,
             round(
                 sum(operational_energy_kwh)
-                    FILTER (WHERE line_item_line_item_type LIKE '%Usage'),
+                    FILTER (WHERE ChargeCategory LIKE '%Usage'),
                 2
             ) AS energy_kwh,
             round(
                 sum(operational_emissions_co2eq_g)
-                    FILTER (WHERE line_item_line_item_type LIKE '%Usage') / 1000,
+                    FILTER (WHERE ChargeCategory LIKE '%Usage') / 1000,
                 2
             ) AS operational_kg,
             round(
                 sum(embodied_emissions_co2eq_g)
-                    FILTER (WHERE line_item_line_item_type LIKE '%Usage') / 1000,
+                    FILTER (WHERE ChargeCategory LIKE '%Usage') / 1000,
                 2
             ) AS embodied_kg,
             round(
                 (
                     coalesce(
                         sum(operational_emissions_co2eq_g)
-                            FILTER (WHERE line_item_line_item_type LIKE '%Usage'),
+                            FILTER (WHERE ChargeCategory LIKE '%Usage'),
                         0
                     )
                     + coalesce(
                         sum(embodied_emissions_co2eq_g)
-                            FILTER (WHERE line_item_line_item_type LIKE '%Usage'),
+                            FILTER (WHERE ChargeCategory LIKE '%Usage'),
                         0
                     )
                 ) / 1000,
@@ -557,20 +612,20 @@ def tag_breakdown_query(where: str) -> str:
             round(
                 coalesce(
                     sum(water_cooling_l)
-                        FILTER (WHERE line_item_line_item_type LIKE '%Usage'),
+                        FILTER (WHERE ChargeCategory LIKE '%Usage'),
                     0
                 )
                 + coalesce(
                     sum(water_electricity_production_l)
-                        FILTER (WHERE line_item_line_item_type LIKE '%Usage'),
+                        FILTER (WHERE ChargeCategory LIKE '%Usage'),
                     0
                 ),
                 2
             ) AS water_usage_l
         FROM filtered
-        WHERE resource_tags IS NOT NULL
-          AND resource_tags[?] IS NOT NULL
-          AND resource_tags[?] != ''
+        WHERE Tags IS NOT NULL
+          AND {tag_value_sql} IS NOT NULL
+          AND {tag_value_sql} != ''
         GROUP BY 1
         ORDER BY total_emissions_kg DESC NULLS LAST
     """
@@ -932,14 +987,7 @@ def render_top_emitters(emitters: pd.DataFrame) -> None:
         return
 
     table = emitters.copy()
-    table["emitter"] = table.apply(
-        lambda row: chart_label(
-            row["line_item_product_code"],
-            row["product_servicecode"],
-            row["line_item_operation"],
-        ),
-        axis=1,
-    )
+    table["emitter"] = table["service_name"].map(chart_label)
     table = table.sort_values("total_emissions_kg", ascending=False)
 
     top = table.iloc[0]
@@ -1079,14 +1127,20 @@ def render_tags(
         st.error(f"Tag '{tag_key}' is not present in the loaded data.")
         return
 
+    kind = tags_column_kind(input_path)
+    if kind is None:
+        st.error("The loaded data has no Tags column.")
+        return
+
+    tag_value_sql, tag_param = tag_value_sql_and_param(kind, tag_key)
     try:
         tags = query_df(
             input_path,
-            tag_breakdown_query(where),
-            params + (tag_key, tag_key, tag_key),
+            tag_breakdown_query(where, tag_value_sql),
+            params + (tag_param, tag_param, tag_param),
         )
     except duckdb.Error as exc:
-        st.error(f"Could not read resource_tags for tag '{tag_key}': {exc}")
+        st.error(f"Could not read Tags for tag '{tag_key}': {exc}")
         return
 
     if tags.empty:

--- a/reporting/report.py
+++ b/reporting/report.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python3
 """
-AWS Environmental Impact Report
+Cloud Environmental Impact Report
 Reads enriched Parquet output, runs analytical queries via DuckDB,
 and produces a Markdown report with recommendations.
+
+Queries use the FOCUS (FinOps Open Cost & Usage Specification) columns emitted
+by all SPRUCE pipelines (AWS CUR, AWS FOCUS, Azure, Azure FOCUS); columns a
+given input does not carry are added as NULLs so every query runs everywhere.
 """
 
 import argparse
@@ -16,6 +20,71 @@ except ImportError:
     sys.exit("duckdb is required — run: pip install -r requirements-report.txt")
 
 import equivalences
+
+
+# Columns the queries below rely on. Any of them missing from the input is
+# added as a typed NULL so the same queries run on the output of every
+# pipeline (SkuMeter is not populated by Azure exports; ListCost is absent
+# from Azure non-FOCUS exports). Tags is handled separately as its type
+# differs per provider (MAP on AWS, JSON string on Azure).
+REPORT_COLUMN_DEFAULTS = {
+    "BILLING_PERIOD": "VARCHAR",
+    "region": "VARCHAR",
+    "ServiceName": "VARCHAR",
+    "ChargeCategory": "VARCHAR",
+    "BilledCost": "DOUBLE",
+    "ListCost": "DOUBLE",
+    "SkuMeter": "VARCHAR",
+    "operational_energy_kwh": "DOUBLE",
+    "operational_emissions_co2eq_g": "DOUBLE",
+    "embodied_emissions_co2eq_g": "DOUBLE",
+    "water_cooling_l": "DOUBLE",
+    "water_electricity_production_l": "DOUBLE",
+    "water_consumption_stress_area_l": "DOUBLE",
+    "carbon_intensity": "DOUBLE",
+    "power_usage_effectiveness": "DOUBLE",
+}
+
+
+# When the input is not hive-partitioned by BILLING_PERIOD, the YYYY-MM split
+# is inferred from the FOCUS ChargePeriodStart column, which pipelines emit as
+# a timestamp, an ISO 8601 string, or a US-style date string.
+BILLING_PERIOD_FROM_CHARGE_PERIOD = r"""
+    CASE WHEN regexp_matches(CAST(ChargePeriodStart AS VARCHAR), '^\d{4}-\d{2}')
+         THEN substr(CAST(ChargePeriodStart AS VARCHAR), 1, 7)
+         ELSE strftime(coalesce(
+                  try_strptime(CAST(ChargePeriodStart AS VARCHAR), '%m/%d/%Y'),
+                  try_strptime(CAST(ChargePeriodStart AS VARCHAR), '%-m/%-d/%Y')),
+              '%Y-%m')
+    END
+""".strip()
+
+
+def create_cur_table(con, parquet_glob):
+    source = f"read_parquet('{parquet_glob}', hive_partitioning=true)"
+    schema_rows = con.execute(f"DESCRIBE SELECT * FROM {source}").fetchall()
+    existing = [str(row[0]) for row in schema_rows]
+    existing_lower = {c.lower() for c in existing}
+    # Inputs may carry a known column under a different case (e.g. a
+    # billing_period parquet column instead of the BILLING_PERIOD hive
+    # partition); alias it to the canonical name the queries use.
+    canonical = {name.lower(): name for name in REPORT_COLUMN_DEFAULTS}
+    exprs = []
+    for c in existing:
+        quoted = '"' + c.replace('"', '""') + '"'
+        wanted = canonical.get(c.lower())
+        if wanted is not None and wanted != c:
+            exprs.append(f'{quoted} AS "{wanted}"')
+        else:
+            exprs.append(quoted)
+    for name, sql_type in REPORT_COLUMN_DEFAULTS.items():
+        if name.lower() in existing_lower:
+            continue
+        if name == "BILLING_PERIOD" and "chargeperiodstart" in existing_lower:
+            exprs.append(f'{BILLING_PERIOD_FROM_CHARGE_PERIOD} AS "{name}"')
+        else:
+            exprs.append(f'CAST(NULL AS {sql_type}) AS "{name}"')
+    con.execute(f"CREATE TABLE cur AS SELECT {', '.join(exprs)} FROM {source}")
 
 
 # ---------------------------------------------------------------------------
@@ -66,32 +135,44 @@ def q_billing_summary(con):
 def q_top_emitters(con):
     sql = """
         SELECT
-            line_item_product_code,
-            product_servicecode,
-            line_item_operation,
+            ServiceName,
             round(sum(operational_emissions_co2eq_g) / 1000, 2) AS co2_usage_kg,
             round(sum(operational_energy_kwh), 2)                AS energy_kwh,
             round(sum(embodied_emissions_co2eq_g) / 1000, 2)    AS co2_embodied_kg,
             round(coalesce(sum(water_cooling_l), 0) + coalesce(sum(water_electricity_production_l), 0), 2) AS water_usage_l
         FROM cur
         WHERE operational_emissions_co2eq_g is not null
-        GROUP BY 1, 2, 3
-        ORDER BY co2_usage_kg DESC, co2_embodied_kg DESC, energy_kwh DESC, line_item_operation
+        GROUP BY 1
+        ORDER BY co2_usage_kg DESC, co2_embodied_kg DESC, energy_kwh DESC, ServiceName
         LIMIT 20
     """
     return con.execute(sql).fetchall()
 
 
 def q_top_instance_types(con):
-    sql = """
+    # The instance type is derived from SkuMeter (FOCUS 1.2). On AWS it
+    # carries the usage type (e.g. EUW2-BoxUsage:t3.xlarge) and the instance
+    # type is the dot-separated lowercase token after the colon. Providers
+    # that do not populate SkuMeter yield no rows for this section.
+    sql = r"""
+        WITH derived AS (
+            SELECT
+                regexp_extract(SkuMeter, ':((?:[a-z][a-z0-9-]*\.)+[a-z0-9]+)$', 1)
+                    AS instance_type,
+                operational_emissions_co2eq_g,
+                embodied_emissions_co2eq_g,
+                water_cooling_l,
+                water_electricity_production_l
+            FROM cur
+        )
         SELECT
-            product_instance_type,
+            instance_type,
             round(sum(operational_emissions_co2eq_g) / 1000, 2) AS co2_usage_kg,
             round(sum(embodied_emissions_co2eq_g) / 1000, 2)    AS co2_embodied_kg,
             round(coalesce(sum(water_cooling_l), 0) + coalesce(sum(water_electricity_production_l), 0), 2) AS water_usage_l
-        FROM cur
-        WHERE len(product_instance_type) > 0
-        GROUP BY product_instance_type
+        FROM derived
+        WHERE len(instance_type) > 0
+        GROUP BY instance_type
         ORDER BY co2_usage_kg DESC
         LIMIT 20
     """
@@ -107,11 +188,11 @@ def q_coverage(con):
             round("total_cost", 2) AS total_cost
         FROM (
             SELECT
-                sum(line_item_unblended_cost) AS "total_cost",
-                sum(line_item_unblended_cost)
+                sum(BilledCost) AS "total_cost",
+                sum(BilledCost)
                     FILTER (WHERE operational_emissions_co2eq_g IS NOT NULL) AS covered
             FROM cur
-            WHERE line_item_line_item_type LIKE '%Usage'
+            WHERE ChargeCategory LIKE '%Usage'
         )
     """
     row = con.execute(sql).fetchone()
@@ -121,14 +202,12 @@ def q_coverage(con):
 def q_uncovered_services(con):
     sql = """
         SELECT
-            line_item_product_code,
-            product_servicecode,
-            line_item_operation,
-            round(sum(line_item_unblended_cost), 2) AS cost
+            ServiceName,
+            round(sum(BilledCost), 2) AS cost
         FROM cur
         WHERE operational_emissions_co2eq_g IS NULL
-          AND line_item_line_item_type LIKE '%Usage'
-        GROUP BY 1, 2, 3
+          AND ChargeCategory LIKE '%Usage'
+        GROUP BY 1
         ORDER BY cost DESC
         LIMIT 20
     """
@@ -143,7 +222,7 @@ def q_regional(con):
                 sum(operational_emissions_co2eq_g)  AS operational_g,
                 sum(embodied_emissions_co2eq_g)     AS embodied_g,
                 sum(operational_energy_kwh)         AS energy_kwh,
-                sum(pricing_public_on_demand_cost)  AS public_cost,
+                sum(ListCost)                       AS public_cost,
                 avg(carbon_intensity)               AS avg_ci,
                 avg(power_usage_effectiveness)      AS pue,
                 coalesce(sum(water_cooling_l), 0) + coalesce(sum(water_electricity_production_l), 0) AS water_l,
@@ -170,13 +249,35 @@ def q_regional(con):
 # Tag discovery
 # ---------------------------------------------------------------------------
 
-def find_tags_by_coverage(con, top_n):
+def tag_value_expr(con):
+    """SQL expression extracting a tag value from the Tags column, with a {key}
+    placeholder for the SQL-escaped tag key. AWS outputs carry Tags as a MAP,
+    Azure ones as a JSON string. Returns None when Tags is absent."""
+    row = con.execute(
+        "SELECT column_type FROM (DESCRIBE cur) WHERE lower(column_name) = 'tags'"
+    ).fetchone()
+    if row is None:
+        return None
+    if row[0].upper().startswith("MAP"):
+        return "Tags['{key}']"
+    return "json_extract_string(TRY_CAST(Tags AS JSON), '$.\"{key}\"')"
+
+
+def escape_tag_key(key):
+    return key.replace("'", "''")
+
+
+def find_tags_by_coverage(con, value_expr, top_n):
     """Return list of (key, coverage_pct) ordered by coverage desc, limited to top_n."""
+    if value_expr is None:
+        return []
+    keys_expr = ("map_keys(Tags)" if value_expr.startswith("Tags[")
+                 else "json_keys(TRY_CAST(Tags AS JSON))")
     try:
-        keys_rows = con.execute("""
-            SELECT DISTINCT unnest(map_keys(resource_tags)) AS tag_key
+        keys_rows = con.execute(f"""
+            SELECT DISTINCT unnest({keys_expr}) AS tag_key
             FROM cur
-            WHERE resource_tags IS NOT NULL
+            WHERE Tags IS NOT NULL
         """).fetchall()
     except Exception:
         return []
@@ -191,11 +292,12 @@ def find_tags_by_coverage(con, top_n):
 
     scored = []
     for key in keys:
+        value = value_expr.format(key=escape_tag_key(key))
         try:
             count = con.execute(f"""
                 SELECT COUNT(*) FROM cur
-                WHERE resource_tags['{key}'] IS NOT NULL
-                  AND resource_tags['{key}'] != ''
+                WHERE {value} IS NOT NULL
+                  AND {value} != ''
             """).fetchone()[0]
             pct = round(count * 100.0 / total, 1)
             if pct > 0:
@@ -207,10 +309,10 @@ def find_tags_by_coverage(con, top_n):
     return scored[:top_n]
 
 
-def q_tag_breakdown(con, key):
+def q_tag_breakdown(con, value_expr, key):
     sql = f"""
         SELECT
-            resource_tags['{key}']                                          AS tag_value,
+            {value_expr.format(key=escape_tag_key(key))}                    AS tag_value,
             round(sum(operational_energy_kwh), 2)                           AS energy_kwh,
             round(sum(operational_emissions_co2eq_g) / 1000, 2)            AS operational_kg,
             round(sum(embodied_emissions_co2eq_g) / 1000, 2)               AS embodied_kg,
@@ -240,10 +342,10 @@ def build_recommendations(coverage_pct, uncovered_rows, regional_rows, billing_r
 
     # Coverage
     if coverage_pct is not None and coverage_pct < 80:
-        top_uncovered = [r for r in uncovered_rows if r[3] and float(r[3]) > 0][:3]
+        top_uncovered = [r for r in uncovered_rows if r[1] and float(r[1]) > 0][:3]
         for r in top_uncovered:
-            svc = r[1] or r[0] or "unknown"
-            cost = r[3]
+            svc = r[0] or "unknown"
+            cost = r[1]
             recs.append(f"⚠ Coverage gap: **{svc}** (${cost:,} uncovered) — SPRUCE does not yet model this service")
 
     # Region carbon intensity
@@ -370,10 +472,7 @@ def main():
         con.execute("LOAD httpfs")
         con.execute("CREATE SECRET (TYPE s3, PROVIDER credential_chain)")
     try:
-        con.execute(f"""
-            CREATE TABLE cur AS
-            SELECT * FROM read_parquet('{parquet_glob}', hive_partitioning=true)
-        """)
+        create_cur_table(con, parquet_glob)
     except Exception as exc:
         sys.exit(f"Failed to load Parquet data from '{parquet_glob}': {exc}")
 
@@ -395,7 +494,8 @@ def main():
     tag_sections = []  # list of (key, coverage_pct, breakdown_rows)
 
     if args.top_tags >= 1:
-        available_tags = find_tags_by_coverage(con, args.top_tags)
+        value_expr = tag_value_expr(con)
+        available_tags = find_tags_by_coverage(con, value_expr, args.top_tags)
 
         if not available_tags:
             sys.stderr.write("\nNo consistent resource tags found in the data.\n")
@@ -414,7 +514,7 @@ def main():
                     idx = int(choice) - 1
                     if 0 <= idx < len(remaining):
                         key, pct = remaining.pop(idx)
-                        breakdown = q_tag_breakdown(con, key)
+                        breakdown = q_tag_breakdown(con, value_expr, key)
                         tag_sections.append((key, pct, breakdown))
                         sys.stderr.write(f"\n### Tag: {key}  ({pct} % coverage)\n\n")
                         sys.stderr.write(md_table(breakdown, ["tag_value", "energy_kwh", "operational_kg", "embodied_kg", "water_usage_l"]))
@@ -431,7 +531,7 @@ def main():
     parts = []
 
     parts.append(
-        f"# AWS Environmental Impact Report\n"
+        f"# Cloud Environmental Impact Report\n"
         f"_{today} | Rows: {row_count:,}_\n\n"
         f"Enriched with [SPRUCE](http://opensourcegreenops.cloud/)\n"
     )
@@ -486,8 +586,7 @@ def main():
     parts.append(section(
         "Top Emitters by Service",
         md_table(emitter_rows, [
-            "product_code", "service_code", "operation",
-            "co2_usage_kg", "energy_kwh", "co2_embodied_kg", "water_usage_l"
+            "service", "co2_usage_kg", "energy_kwh", "co2_embodied_kg", "water_usage_l"
         ])
     ))
 
@@ -502,7 +601,7 @@ def main():
         coverage_body = f"- **{coverage_pct} %** of unblended costs have emissions data\n\n"
     else:
         coverage_body = "- _Coverage data unavailable_\n\n"
-    coverage_body += md_table(uncovered_rows, ["product_code", "service_code", "operation", "cost_usd"])
+    coverage_body += md_table(uncovered_rows, ["service", "cost_usd"])
     parts.append(section("Coverage", coverage_body))
 
     # Regional


### PR DESCRIPTION
Fixes #239

Makes the reporting scripts (`reporting/report.py`, `reporting/dashboard.py`) provider-neutral by querying the FOCUS (FinOps Open Cost & Usage Specification) columns emitted by all SPRUCE pipelines, instead of raw AWS CUR columns.

## What changed

**Pipeline side**
- `FOCUSColumns` bridge modules map provider-native billing columns to FOCUS names (`BilledCost`, `ServiceName`, `ChargeCategory`, `RegionId`, `SubAccountId`, `ChargePeriodStart/End`, `Tags`, `SkuMeter`, ...) for the native AWS and Azure pipelines; FOCUS exports already carry them
- The `InstanceTypeExtraction` modules and `SpruceColumn.INSTANCE_TYPE` were removed; the instance type is now derived from `SkuMeter` on the reporting side

**Reporting side**
- All queries use standard FOCUS columns plus SPRUCE-generated columns only — no provider-specific `x_` columns
- Top instance types are parsed from `SkuMeter` (FOCUS 1.2, e.g. `EUW2-BoxUsage:t3.xlarge`); inputs that do not populate it get an empty section
- Tag breakdowns handle `Tags` stored as a `MAP` (AWS) or a JSON string (Azure)
- `BILLING_PERIOD` is inferred from `ChargePeriodStart` when the input is not hive-partitioned by billing period (handles ISO timestamps, ISO strings, and US-style Azure dates)
- Columns missing from an input are injected as typed NULLs, and known columns are aliased to their canonical case, so the same queries run on the output of every pipeline
- Docs and reporting README updated to match

## Testing

Report and dashboard verified end-to-end against four enriched datasets: AWS CUR (hourly, hive-partitioned), AWS FOCUS (daily, flat), Azure cost details, and Azure FOCUS. Totals match across export formats of the same account; per-service splits legitimately differ where the provider's own `ServiceName` taxonomy differs from meter categories.