### PR TITLE
Handle Azure Date column inferred as DateType by Spark 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,26 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.5.5</version>
+                    <configuration>
+                        <!-- module opens needed to run an embedded Spark session on JDK 17+;
+                             @{argLine} keeps the jacoco agent -->
+                        <argLine>@{argLine}
+                            --add-opens=java.base/java.lang=ALL-UNNAMED
+                            --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+                            --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+                            --add-opens=java.base/java.io=ALL-UNNAMED
+                            --add-opens=java.base/java.net=ALL-UNNAMED
+                            --add-opens=java.base/java.nio=ALL-UNNAMED
+                            --add-opens=java.base/java.util=ALL-UNNAMED
+                            --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+                            --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
+                            --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+                            --add-opens=java.base/sun.nio.cs=ALL-UNNAMED
+                            --add-opens=java.base/sun.security.action=ALL-UNNAMED
+                            --add-opens=java.base/sun.util.calendar=ALL-UNNAMED
+                            -Djdk.reflect.useDirectMethodHandle=false
+                        </argLine>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/src/main/java/com/digitalpebble/spruce/AzureColumn.java
+++ b/src/main/java/com/digitalpebble/spruce/AzureColumn.java
@@ -4,6 +4,7 @@ package com.digitalpebble.spruce;
 
 import org.apache.spark.sql.types.DataType;
 
+import static org.apache.spark.sql.types.DataTypes.DateType;
 import static org.apache.spark.sql.types.DataTypes.DoubleType;
 import static org.apache.spark.sql.types.DataTypes.StringType;
 
@@ -19,7 +20,7 @@ public class AzureColumn extends RowColumn {
     public static AzureColumn QUANTITY = new AzureColumn("Quantity", DoubleType);
     public static AzureColumn COST_IN_BILLING_CURRENCY = new AzureColumn("CostInBillingCurrency", DoubleType);
     public static AzureColumn SUBSCRIPTION_ID = new AzureColumn("SubscriptionId", StringType);
-    public static AzureColumn DATE = new AzureColumn("Date", StringType);
+    public static AzureColumn DATE = new AzureColumn("Date", DateType);
 
     AzureColumn(String l, DataType t) {
         super(l, t);

--- a/src/main/java/com/digitalpebble/spruce/RowColumn.java
+++ b/src/main/java/com/digitalpebble/spruce/RowColumn.java
@@ -5,6 +5,11 @@ package com.digitalpebble.spruce;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.types.DataType;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+
 /**
  * Abstract base class for native column types that work with Spark Row objects.
  * Provides shared functionality for extracting values from Row objects.
@@ -36,6 +41,38 @@ public abstract class RowColumn extends Column {
     /** Returns the String value for this column in the given row. */
     public String getString(Row r) {
         return getString(r, false);
+    }
+
+    private static final List<DateTimeFormatter> DATE_FORMATS = List.of(
+            DateTimeFormatter.ISO_LOCAL_DATE,
+            DateTimeFormatter.ofPattern("MM/dd/yyyy"),
+            DateTimeFormatter.ofPattern("M/d/yyyy"));
+
+    /**
+     * Returns the LocalDate value for this column in the given row, or null if the value is
+     * null or a string that cannot be parsed as a date. Handles both Spark date representations
+     * (java.sql.Date, or java.time.LocalDate when the Java 8 datetime API is enabled) and
+     * normalises string values, for inputs where schema inference left the column as a string.
+     */
+    public LocalDate getDate(Row r) {
+        Object value = r.get(resolveIndex(r));
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof java.sql.Date date) {
+            return date.toLocalDate();
+        }
+        if (value instanceof LocalDate date) {
+            return date;
+        }
+        String trimmed = value.toString().trim();
+        for (DateTimeFormatter format : DATE_FORMATS) {
+            try {
+                return LocalDate.parse(trimmed, format);
+            } catch (DateTimeParseException ignored) {
+            }
+        }
+        return null;
     }
 
     /** Returns true if the value for this column is null in the given row. */

--- a/src/main/java/com/digitalpebble/spruce/SparkJob.java
+++ b/src/main/java/com/digitalpebble/spruce/SparkJob.java
@@ -10,14 +10,55 @@ import scala.Option;
 import java.io.IOException;
 import java.nio.file.Paths;
 
+import static org.apache.spark.sql.functions.coalesce;
 import static org.apache.spark.sql.functions.concat;
 import static org.apache.spark.sql.functions.lit;
 import static org.apache.spark.sql.functions.not;
+import static org.apache.spark.sql.functions.try_to_date;
 import static org.apache.spark.sql.functions.when;
 
 public class SparkJob {
 
     private static final org.slf4j.Logger LOG = org.slf4j.LoggerFactory.getLogger(SparkJob.class);
+
+    /**
+     * Fixes up the types and values of an Azure report loaded from CSV, where inferSchema does
+     * not always produce what the enrichment modules expect.
+     */
+    static Dataset<Row> normalizeAzureColumns(Dataset<Row> dataframe, ReportFormat reportFormat) {
+        // inferSchema may read numeric columns as strings; force them to double
+        RowColumn[] numericColumns = reportFormat == ReportFormat.FOCUS
+                ? new RowColumn[]{FOCUSColumn.CONSUMED_QUANTITY, FOCUSColumn.BILLED_COST}
+                : new RowColumn[]{AzureColumn.QUANTITY, AzureColumn.COST_IN_BILLING_CURRENCY};
+        java.util.List<String> columns = java.util.Arrays.asList(dataframe.columns());
+        for (RowColumn column : numericColumns) {
+            if (columns.contains(column.getLabel())) {
+                dataframe = dataframe.withColumn(column.getLabel(),
+                        dataframe.col(column.getLabel()).cast("double"));
+            }
+        }
+        // inferSchema reads Date as a date when values are ISO but as a string when they
+        // are US-formatted; normalise to a date either way. try_to_date rather than a cast
+        // as ANSI mode makes a failed cast throw instead of yielding null.
+        if (columns.contains(AzureColumn.DATE.getLabel())) {
+            org.apache.spark.sql.Column date = dataframe.col(AzureColumn.DATE.getLabel());
+            dataframe = dataframe.withColumn(AzureColumn.DATE.getLabel(),
+                    coalesce(try_to_date(date),
+                            try_to_date(date, "MM/dd/yyyy"),
+                            try_to_date(date, "M/d/yyyy")));
+        }
+        // EA cost details exports carry Tags as a JSON fragment missing the enclosing braces
+        // (https://github.com/microsoft/finops-toolkit/discussions/2053); wrap it so the
+        // column always holds a valid JSON object, as in MCA and FOCUS exports
+        if (columns.contains("Tags")) {
+            org.apache.spark.sql.Column tags = dataframe.col("Tags");
+            dataframe = dataframe.withColumn("Tags",
+                    when(tags.isNotNull().and(not(tags.startsWith("{"))),
+                            concat(lit("{"), tags, lit("}")))
+                            .otherwise(tags));
+        }
+        return dataframe;
+    }
 
     public static void main(String[] args) {
 
@@ -77,27 +118,7 @@ public class SparkJob {
             dataframe = spark.read().option("header", "true").option("inferSchema", "true")
                     .option("quote", "\"")
                     .option("escape", "\"").csv(inputPath);
-            // inferSchema may read numeric columns as strings; force them to double
-            RowColumn[] numericColumns = reportFormat == ReportFormat.FOCUS
-                    ? new RowColumn[]{FOCUSColumn.CONSUMED_QUANTITY, FOCUSColumn.BILLED_COST}
-                    : new RowColumn[]{AzureColumn.QUANTITY, AzureColumn.COST_IN_BILLING_CURRENCY};
-            java.util.List<String> columns = java.util.Arrays.asList(dataframe.columns());
-            for (RowColumn column : numericColumns) {
-                if (columns.contains(column.getLabel())) {
-                    dataframe = dataframe.withColumn(column.getLabel(),
-                            dataframe.col(column.getLabel()).cast("double"));
-                }
-            }
-            // EA cost details exports carry Tags as a JSON fragment missing the enclosing braces
-            // (https://github.com/microsoft/finops-toolkit/discussions/2053); wrap it so the
-            // column always holds a valid JSON object, as in MCA and FOCUS exports
-            if (columns.contains("Tags")) {
-                org.apache.spark.sql.Column tags = dataframe.col("Tags");
-                dataframe = dataframe.withColumn("Tags",
-                        when(tags.isNotNull().and(not(tags.startsWith("{"))),
-                                concat(lit("{"), tags, lit("}")))
-                                .otherwise(tags));
-            }
+            dataframe = normalizeAzureColumns(dataframe, reportFormat);
         } else {
             dataframe = spark.read().parquet(inputPath);
         }

--- a/src/main/java/com/digitalpebble/spruce/modules/azure/FOCUSColumns.java
+++ b/src/main/java/com/digitalpebble/spruce/modules/azure/FOCUSColumns.java
@@ -7,9 +7,6 @@ import com.digitalpebble.spruce.EnrichmentModule;
 import org.apache.spark.sql.Row;
 
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
-import java.util.List;
 import java.util.Map;
 
 import static com.digitalpebble.spruce.AzureColumn.CHARGE_TYPE;
@@ -37,11 +34,6 @@ import static com.digitalpebble.spruce.SpruceColumn.REGION;
  * (e.g. {@code BillingCurrency}, {@code Tags}) are left untouched and pass through unchanged.
  **/
 public class FOCUSColumns implements EnrichmentModule {
-
-    private static final List<DateTimeFormatter> DATE_FORMATS = List.of(
-            DateTimeFormatter.ISO_LOCAL_DATE,
-            DateTimeFormatter.ofPattern("MM/dd/yyyy"),
-            DateTimeFormatter.ofPattern("M/d/yyyy"));
 
     @Override
     public Column[] columnsNeeded() {
@@ -87,28 +79,11 @@ public class FOCUSColumns implements EnrichmentModule {
             enrichedValues.put(SUB_ACCOUNT_ID, subscriptionId);
         }
 
-        String date = DATE.getString(row);
+        // Azure usage rows have daily granularity, so the charge period spans one day
+        LocalDate date = DATE.getDate(row);
         if (date != null) {
-            enrichedValues.put(CHARGE_PERIOD_START, date);
-            String end = nextDay(date);
-            if (end != null) {
-                enrichedValues.put(CHARGE_PERIOD_END, end);
-            }
+            enrichedValues.put(CHARGE_PERIOD_START, date.toString());
+            enrichedValues.put(CHARGE_PERIOD_END, date.plusDays(1).toString());
         }
-    }
-
-    /**
-     * Returns the day after the given Azure date string, in the same format, or null if it cannot
-     * be parsed. Azure usage rows have daily granularity, so the charge period spans one day.
-     **/
-    private static String nextDay(String date) {
-        String trimmed = date.trim();
-        for (DateTimeFormatter format : DATE_FORMATS) {
-            try {
-                return LocalDate.parse(trimmed, format).plusDays(1).format(format);
-            } catch (DateTimeParseException ignored) {
-            }
-        }
-        return null;
     }
 }

--- a/src/test/java/com/digitalpebble/spruce/SparkJobTest.java
+++ b/src/test/java/com/digitalpebble/spruce/SparkJobTest.java
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalpebble.spruce;
+
+import com.digitalpebble.spruce.modules.azure.FOCUSColumns;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.DataTypes;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.digitalpebble.spruce.FOCUSColumn.CHARGE_PERIOD_END;
+import static com.digitalpebble.spruce.FOCUSColumn.CHARGE_PERIOD_START;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Reads real Azure CSVs through Spark schema inference, which unit tests building rows by hand
+ * cannot cover: Spark 4 infers ISO date columns as DateType while US-formatted ones stay strings
+ * (https://github.com/DigitalPebble/spruce/issues/246).
+ **/
+public class SparkJobTest {
+
+    private static SparkSession spark;
+
+    @BeforeAll
+    static void startSpark() {
+        spark = SparkSession.builder()
+                .appName("SparkJobTest")
+                .master("local[1]")
+                .config("spark.ui.enabled", "false")
+                .getOrCreate();
+    }
+
+    @AfterAll
+    static void stopSpark() {
+        spark.stop();
+    }
+
+    private Dataset<Row> readCsv(String resource) {
+        String path = getClass().getResource(resource).getPath();
+        return spark.read().option("header", "true").option("inferSchema", "true")
+                .option("quote", "\"")
+                .option("escape", "\"").csv(path);
+    }
+
+    @Test
+    void normalizesInferredDateColumn() {
+        Dataset<Row> dataframe = readCsv("/azure/native-iso-dates.csv");
+        // the premise of issue #246: Spark 4 infers ISO dates as DateType, not StringType
+        assertEquals(DataTypes.DateType, dataframe.schema().apply("Date").dataType());
+
+        dataframe = SparkJob.normalizeAzureColumns(dataframe, ReportFormat.NATIVE);
+
+        assertEquals(DataTypes.DateType, dataframe.schema().apply("Date").dataType());
+        assertEquals(DataTypes.DoubleType, dataframe.schema().apply("Quantity").dataType());
+        assertEquals(DataTypes.DoubleType,
+                dataframe.schema().apply("CostInBillingCurrency").dataType());
+
+        // running the module on the inferred rows used to throw a ClassCastException
+        FOCUSColumns module = new FOCUSColumns();
+        Row first = dataframe.collectAsList().get(0);
+        Map<Column, Object> enriched = new HashMap<>();
+        module.enrich(first, enriched);
+
+        assertEquals("2026-06-29", enriched.get(CHARGE_PERIOD_START));
+        assertEquals("2026-06-30", enriched.get(CHARGE_PERIOD_END));
+    }
+
+    @Test
+    void normalizesUsFormattedDateColumn() {
+        Dataset<Row> dataframe = readCsv("/azure/native-us-dates.csv");
+        // US-formatted dates are not recognised by schema inference and stay strings
+        assertEquals(DataTypes.StringType, dataframe.schema().apply("Date").dataType());
+
+        dataframe = SparkJob.normalizeAzureColumns(dataframe, ReportFormat.NATIVE);
+
+        assertEquals(DataTypes.DateType, dataframe.schema().apply("Date").dataType());
+
+        FOCUSColumns module = new FOCUSColumns();
+        Row first = dataframe.collectAsList().get(0);
+        Map<Column, Object> enriched = new HashMap<>();
+        module.enrich(first, enriched);
+
+        assertEquals("2026-06-29", enriched.get(CHARGE_PERIOD_START));
+        assertEquals("2026-06-30", enriched.get(CHARGE_PERIOD_END));
+    }
+}

--- a/src/test/java/com/digitalpebble/spruce/modules/azure/FOCUSColumnsTest.java
+++ b/src/test/java/com/digitalpebble/spruce/modules/azure/FOCUSColumnsTest.java
@@ -12,6 +12,8 @@ import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Test;
 
+import java.sql.Date;
+import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -38,7 +40,7 @@ public class FOCUSColumnsTest {
 
     @Test
     void mapsAllColumns() {
-        Row row = generateRow(12.5, "Storage", "Usage", "sub-123", "2026-06-23");
+        Row row = generateRow(12.5, "Storage", "Usage", "sub-123", Date.valueOf("2026-06-23"));
         Map<Column, Object> enriched = new HashMap<>();
         enriched.put(REGION, "eastus");
 
@@ -55,7 +57,7 @@ public class FOCUSColumnsTest {
 
     @Test
     void chargePeriodEndIsNextDay() {
-        Row row = generateRow(1.0, "Storage", "Usage", "sub-123", "2026-12-31");
+        Row row = generateRow(1.0, "Storage", "Usage", "sub-123", Date.valueOf("2026-12-31"));
         Map<Column, Object> enriched = new HashMap<>();
 
         module.enrich(row, enriched);
@@ -65,8 +67,30 @@ public class FOCUSColumnsTest {
     }
 
     @Test
+    void acceptsLocalDateValues() {
+        Row row = generateRow(1.0, "Storage", "Usage", "sub-123", LocalDate.parse("2026-06-23"));
+        Map<Column, Object> enriched = new HashMap<>();
+
+        module.enrich(row, enriched);
+
+        assertEquals("2026-06-23", enriched.get(CHARGE_PERIOD_START));
+        assertEquals("2026-06-24", enriched.get(CHARGE_PERIOD_END));
+    }
+
+    @Test
+    void normalisesStringDates() {
+        Row row = generateRow(1.0, "Storage", "Usage", "sub-123", "06/23/2026");
+        Map<Column, Object> enriched = new HashMap<>();
+
+        module.enrich(row, enriched);
+
+        assertEquals("2026-06-23", enriched.get(CHARGE_PERIOD_START));
+        assertEquals("2026-06-24", enriched.get(CHARGE_PERIOD_END));
+    }
+
+    @Test
     void regionIdComesFromEnrichedRegion() {
-        Row row = generateRow(1.0, "Storage", "Usage", "sub-123", "2026-06-23");
+        Row row = generateRow(1.0, "Storage", "Usage", "sub-123", Date.valueOf("2026-06-23"));
         Map<Column, Object> enriched = new HashMap<>();
         enriched.put(REGION, "westeurope");
 
@@ -82,11 +106,12 @@ public class FOCUSColumnsTest {
                 new StructField("MeterCategory", DataTypes.StringType, true, Metadata.empty()),
                 new StructField("ChargeType", DataTypes.StringType, true, Metadata.empty()),
                 new StructField("SubscriptionId", DataTypes.StringType, true, Metadata.empty()),
-                new StructField("Date", DataTypes.StringType, true, Metadata.empty()),
+                new StructField("Date", DataTypes.DateType, true, Metadata.empty()),
                 new StructField("ResourceLocation", DataTypes.StringType, true, Metadata.empty())
         });
         Row row = new GenericRowWithSchema(
-                new Object[]{1.0, "Storage", "Usage", "sub-123", "2026-06-23", "EastUS"}, withLocation);
+                new Object[]{1.0, "Storage", "Usage", "sub-123", Date.valueOf("2026-06-23"), "EastUS"},
+                withLocation);
         Map<Column, Object> enriched = new HashMap<>();
 
         module.enrich(row, enriched);
@@ -96,7 +121,7 @@ public class FOCUSColumnsTest {
 
     @Test
     void nullCostProducesNoBilledCost() {
-        Row row = generateRow(null, "Storage", "Usage", "sub-123", "2026-06-23");
+        Row row = generateRow(null, "Storage", "Usage", "sub-123", Date.valueOf("2026-06-23"));
         Map<Column, Object> enriched = new HashMap<>();
 
         module.enrich(row, enriched);
@@ -105,19 +130,19 @@ public class FOCUSColumnsTest {
     }
 
     @Test
-    void unparseableDateLeavesEndNull() {
+    void unparseableDateLeavesChargePeriodNull() {
         Row row = generateRow(1.0, "Storage", "Usage", "sub-123", "not-a-date");
         Map<Column, Object> enriched = new HashMap<>();
 
         module.enrich(row, enriched);
 
-        assertEquals("not-a-date", enriched.get(CHARGE_PERIOD_START));
+        assertNull(enriched.get(CHARGE_PERIOD_START));
         assertNull(enriched.get(CHARGE_PERIOD_END));
     }
 
     @Test
     void missingRegionLeavesRegionIdNull() {
-        Row row = generateRow(1.0, "Storage", "Usage", "sub-123", "2026-06-23");
+        Row row = generateRow(1.0, "Storage", "Usage", "sub-123", Date.valueOf("2026-06-23"));
         Map<Column, Object> enriched = new HashMap<>();
 
         module.enrich(row, enriched);
@@ -138,10 +163,11 @@ public class FOCUSColumnsTest {
     /**
      * Builds a row matching the module schema: the columnsNeeded() come first
      * (CostInBillingCurrency, MeterCategory, ChargeType, SubscriptionId, Date),
-     * followed by the columnsAdded() left null.
+     * followed by the columnsAdded() left null. The date is usually a java.sql.Date, matching
+     * what Spark passes for a DateType column, but the module also tolerates strings.
      **/
     private Row generateRow(Double cost, String meterCategory, String chargeType,
-                            String subscriptionId, String date) {
+                            String subscriptionId, Object date) {
         Object[] values = new Object[]{
                 cost, meterCategory, chargeType, subscriptionId, date,
                 null, null, null, null, null, null, null

--- a/src/test/resources/azure/native-iso-dates.csv
+++ b/src/test/resources/azure/native-iso-dates.csv
@@ -1,0 +1,3 @@
+Date,ChargeType,MeterCategory,SubscriptionId,ResourceLocation,Quantity,CostInBillingCurrency,Tags
+2026-06-29,Usage,Storage,sub-123,spaincentral,4.2,0.05,"""env"": ""prod"""
+2026-06-26,Usage,Virtual Machines,sub-123,spaincentral,24,2.208747,

--- a/src/test/resources/azure/native-us-dates.csv
+++ b/src/test/resources/azure/native-us-dates.csv
@@ -1,0 +1,3 @@
+Date,ChargeType,MeterCategory,SubscriptionId,ResourceLocation,Quantity,CostInBillingCurrency
+06/29/2026,Usage,Storage,sub-123,spaincentral,4.2,0.05
+12/31/2026,Usage,Virtual Machines,sub-123,spaincentral,24,2.208747


### PR DESCRIPTION
Fixes #246

Spark 4 infers ISO-formatted `Date` columns in Azure CSV exports as `DateType`, so the `getString()` call in the azure `FOCUSColumns` module threw a `ClassCastException`. As discussed on the issue, this keeps the richer type rather than casting back to string.

## Changes

- **SparkJob**: the Azure CSV post-load fix-ups are extracted into a testable `normalizeAzureColumns()` method, which now also normalises `Date` to `DateType` with `coalesce(try_to_date(...))` over the known formats (ISO, `MM/dd/yyyy`, `M/d/yyyy`). `try_to_date` rather than a cast because ANSI mode makes a failed cast throw instead of yielding null.
- **AzureColumn**: `DATE` is now declared `DateType`.
- **RowColumn**: new `getDate(Row)` accessor returning `LocalDate`; accepts `java.sql.Date`, `LocalDate` (Java 8 datetime API) and falls back to parsing strings.
- **azure/FOCUSColumns**: reads the date with `getDate()` and does `plusDays(1)`; the format-guessing `nextDay()` is gone. Side effect: `ChargePeriodStart/End` are now always emitted as ISO dates, even for `MM/dd/yyyy` inputs.
- **pom.xml**: surefire gets the standard Spark-on-JDK17+ `--add-opens` list (keeping the jacoco agent via `@{argLine}`), needed for the new test.
- **Tests**: `FOCUSColumnsTest` builds rows with real date values plus string-fallback coverage, and a new `SparkJobTest` reads two small CSVs through actual `inferSchema` — asserting the inference premise and that enrichment no longer throws — since rows built by hand could not catch this.

## Verification

Beyond the unit tests (316 pass), ran `SparkJob` end-to-end on `azure-examples/EA-Cost-Actual.csv` both as-is (US dates) and with the `Date` column converted to ISO (the Spark 4 `DateType` inference scenario from the issue): both runs complete, `Date` lands as a proper `DATE` in the output parquet, charge periods are ISO strings and the emissions columns are populated.

## Left out deliberately

Typing `ChargePeriodStart/End` as dates (raised in the issue discussion): the AWS bridge writes hourly CUR timestamps into the same columns, so that needs its own PR.