### PR TITLE
Include reporting tools in the Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+**/__pycache__
+target/
+data/
+output-*
+azure-examples/
+artifacts/
+docs/site/
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,28 @@ COPY pom.xml /home/app
 RUN mvn -B -ntp -Dmaven.test.skip=true -f /home/app/pom.xml clean package
 
 FROM apache/spark:4.1.2-java17
+
+USER root
+# python3-venv for the reporting tools; pango/cairo/gdk-pixbuf and fonts for
+# weasyprint (PDF output of report.py)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 python3-venv \
+        libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf-2.0-0 \
+        fonts-dejavu-core \
+    && rm -rf /var/lib/apt/lists/*
+
+# requirements copied on their own so editing the scripts does not invalidate
+# the pip layer
+COPY reporting/requirements-report.txt reporting/requirements-dashboard.txt /opt/spruce/reporting/
+RUN python3 -m venv /opt/spruce/venv \
+    && /opt/spruce/venv/bin/pip install --no-cache-dir \
+       -r /opt/spruce/reporting/requirements-report.txt \
+       -r /opt/spruce/reporting/requirements-dashboard.txt
+COPY reporting /opt/spruce/reporting
+
 COPY --from=build /home/app/target/spruce-*.jar /usr/local/lib/spruce.jar
-ENTRYPOINT ["/opt/spark/bin/spark-submit", "--driver-memory", "4g", "--master", "local[*]", "/usr/local/lib/spruce.jar"]
+COPY entrypoint.sh /opt/spruce/entrypoint.sh
+
+USER spark
+EXPOSE 8501
+ENTRYPOINT ["/opt/spruce/entrypoint.sh"]

--- a/docs/src/tutorial/with-docker.md
+++ b/docs/src/tutorial/with-docker.md
@@ -60,3 +60,28 @@ The options `-p` (cloud provider) and `-f` (report format) are described in [Qui
 
 The directory _output_ contains an enriched copy of the input reports. See [Explore the results](results.md) to understand
 what the output contains.
+
+## Reporting with Docker
+
+The same image contains the [reporting tools](https://github.com/DigitalPebble/spruce/tree/main/reporting),
+so you can generate a report or explore the enriched output interactively without installing Python.
+
+Generate a static report (format inferred from the suffix: `.md`, `.html` or `.pdf`):
+
+```shell
+docker run --rm -v $(pwd):/workspace -w /workspace \
+ghcr.io/digitalpebble/spruce \
+report -i output -o report.html
+```
+
+Launch the interactive dashboard, then open [http://localhost:8501](http://localhost:8501):
+
+```shell
+docker run --rm -p 8501:8501 -v $(pwd):/workspace -w /workspace \
+ghcr.io/digitalpebble/spruce \
+dashboard -i output
+```
+
+The image version determines both the SPRUCE jar and the reporting scripts, so when
+enriching and reporting are done at different times, use the same explicit tag
+(e.g. `ghcr.io/digitalpebble/spruce:1.1`) for both steps rather than relying on `latest`.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+case "$1" in
+  report)
+    shift
+    exec /opt/spruce/venv/bin/python /opt/spruce/reporting/report.py "$@"
+    ;;
+  dashboard)
+    shift
+    exec /opt/spruce/venv/bin/streamlit run /opt/spruce/reporting/dashboard.py \
+      --server.address=0.0.0.0 --server.headless=true \
+      --browser.gatherUsageStats=false -- "$@"
+    ;;
+  *)
+    exec /opt/spark/bin/spark-submit --driver-memory 4g --master "local[*]" \
+      /usr/local/lib/spruce.jar "$@"
+    ;;
+esac

--- a/reporting/README.md
+++ b/reporting/README.md
@@ -14,6 +14,9 @@ pip install -r reporting/requirements-report.txt
 pip install -r reporting/requirements-dashboard.txt
 ```
 
+Alternatively, run the tools from the SPRUCE Docker image without installing
+anything — see [Running with Docker](#running-with-docker) below.
+
 ## Input Data
 
 Both tools expect SPRUCE-enriched Parquet files as input. These files contain:
@@ -91,6 +94,27 @@ streamlit run reporting/dashboard.py -- --input s3://bucket/path/to/enriched/
 ```
 
 Requires AWS credentials configured in your environment.
+
+## Running with Docker
+
+The `ghcr.io/digitalpebble/spruce` image ships these scripts and their
+dependencies alongside the SPRUCE jar, so the reporting tools always match the
+version of SPRUCE that produced the enriched output. The first argument selects
+the tool (`report` or `dashboard`); anything else is passed to `spark-submit`
+for enrichment.
+
+```bash
+# Static report
+docker run --rm -v $(pwd):/workspace -w /workspace \
+  ghcr.io/digitalpebble/spruce report -i output -o report.html
+
+# Interactive dashboard on http://localhost:8501
+docker run --rm -p 8501:8501 -v $(pwd):/workspace -w /workspace \
+  ghcr.io/digitalpebble/spruce dashboard -i output
+```
+
+When enriching and reporting at different times, pin the same image tag for
+both steps rather than relying on `latest`.
 
 ## Data Requirements
 


### PR DESCRIPTION
Fixes #253

The Docker image now ships the reporting scripts and their dependencies alongside the SPRUCE jar, so the report generator and the dashboard can be run with Docker only, at a version matching the jar (both are baked in from the same release tag).

Changes:
- **Dockerfile**: installs Python + a venv with both requirements files, plus the pango/cairo libs and fonts needed by weasyprint for PDF output; copies `reporting/` into the image; switches back to the base image's `spark` user; `EXPOSE 8501`
- **entrypoint.sh** (new): dispatches on the first argument — `report` runs `report.py`, `dashboard` runs Streamlit (bound to `0.0.0.0`, headless), anything else falls through to `spark-submit` as before, so existing enrichment commands are unchanged
- **.dockerignore** (new): keeps `__pycache__`, `target/`, sample data and output directories out of the build context
- **Docs**: new "Reporting with Docker" section in the Docker tutorial and a "Running with Docker" section in `reporting/README.md`, both recommending pinning the same image tag for enriching and reporting

Usage:
```shell
# static report (.md, .html or .pdf)
docker run --rm -v $(pwd):/workspace -w /workspace \
  ghcr.io/digitalpebble/spruce report -i output -o report.html

# interactive dashboard on http://localhost:8501
docker run --rm -p 8501:8501 -v $(pwd):/workspace -w /workspace \
  ghcr.io/digitalpebble/spruce dashboard -i output
```

Tested locally: image builds, `report` produces a valid PDF from enriched sample data, the dashboard comes up healthy on port 8501, and the default entrypoint still runs the jar. No change needed in `docker.yml`. Note the image grows to ~3 GB (from ~1.7 GB) due to the Python stack; if that becomes an issue a separate reporting image could be split out later.