### PR TITLE
Allow setting the driver memory of the Docker image

### DIFF
--- a/docs/src/howto/s3.md
+++ b/docs/src/howto/s3.md
@@ -48,11 +48,10 @@ You need to pass the environment keys and values to the container with `-e` e.g.
 docker run -it --rm --name spruce \
 -e AWS_ACCESS_KEY_ID \
 -e AWS_SECRET_ACCESS_KEY \
-spruce_s3  \
-/opt/spark/bin/spark-submit  \
---class com.digitalpebble.spruce.SparkJob \
---driver-memory 4g \
---master 'local[*]' \
-/usr/local/lib/spruce.jar \
+-e SPRUCE_DRIVER_MEMORY=8g \
+spruce_s3 \
 -i s3a://BUCKET_WITH_CURS/PATH/ -o s3a://OUTPUT_BUCKET/PATH/
 ```
+
+`SPRUCE_DRIVER_MEMORY` is optional and sets the heap given to Spark; see
+[Allocating more memory](../tutorial/with-docker.md#allocating-more-memory).

--- a/docs/src/tutorial/with-docker.md
+++ b/docs/src/tutorial/with-docker.md
@@ -61,6 +61,32 @@ The options `-p` (cloud provider) and `-f` (report format) are described in [Qui
 The directory _output_ contains an enriched copy of the input reports. See [Explore the results](results.md) to understand
 what the output contains.
 
+## Allocating more memory
+
+The container runs SPRUCE with Spark in local mode, where a single JVM (the Spark driver) does all
+the work. It defaults to 4 GB of heap, which is enough for the tutorial data but can be too little
+for large reports — typically showing up as `java.lang.OutOfMemoryError: Java heap space` or as jobs
+slowing down to a crawl in garbage collection.
+
+Set the `SPRUCE_DRIVER_MEMORY` environment variable to give the driver a larger heap:
+
+```shell
+docker run --rm -v $(pwd):/workspace -w /workspace \
+-e SPRUCE_DRIVER_MEMORY=16g \
+ghcr.io/digitalpebble/spruce \
+-i curs -o output
+```
+
+The value is passed to `spark-submit --driver-memory`, so it takes the usual Spark suffixes
+(`512m`, `8g`, ...).
+
+Make sure the container is actually allowed to use that much: on Docker Desktop the VM has its own
+memory limit, and if you constrain the container with `--memory`, keep the heap comfortably below it
+so there is room for the JVM's off-heap memory.
+
+`SPRUCE_DRIVER_MEMORY` only applies to the enrichment job. The `report` and `dashboard` commands do
+not run Spark and ignore it.
+
 ## Reporting with Docker
 
 The same image contains the [reporting tools](https://github.com/DigitalPebble/spruce/tree/main/reporting),

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@ case "$1" in
       --browser.gatherUsageStats=false -- "$@"
     ;;
   *)
-    exec /opt/spark/bin/spark-submit --driver-memory 4g --master "local[*]" \
+    exec /opt/spark/bin/spark-submit --driver-memory "${SPRUCE_DRIVER_MEMORY:-4g}" --master "local[*]" \
       /usr/local/lib/spruce.jar "$@"
     ;;
 esac


### PR DESCRIPTION
The Docker entrypoint hardcodes `--driver-memory 4g`, and there is no way to raise it from the `docker run` command line:

- `SPARK_DRIVER_MEMORY` loses to the explicit `--driver-memory` flag;
- `SPARK_SUBMIT_OPTS=-Xmx16g` is emitted *before* the `-Xmx4g` derived from `--driver-memory`, so the JVM takes the 4g;
- `spark.driver.extraJavaOptions` rejects `-Xmx` outright.

The only workaround was `--entrypoint /opt/spark/bin/spark-submit` plus the full spark-submit command.

The driver memory is now read from `SPRUCE_DRIVER_MEMORY`, defaulting to `4g` so existing invocations are unchanged:

```shell
docker run --rm -v $(pwd):/workspace -w /workspace \
-e SPRUCE_DRIVER_MEMORY=16g \
ghcr.io/digitalpebble/spruce \
-i curs -o output
```

Verified with `SPARK_PRINT_LAUNCH_COMMAND=1` on an image built from this branch: no variable gives `-Xmx4g`, `SPRUCE_DRIVER_MEMORY=9g` gives `-Xmx9g`.

Documentation: a new *Allocating more memory* section in the Docker tutorial, including the caveats that the container must actually be allowed that much memory and that `report`/`dashboard` ignore the variable.

Also fixes the Docker example in the S3 how-to, which still passed a whole `spark-submit` invocation as arguments — since the entrypoint was introduced those are passed to the SPRUCE job instead, so the example could not work as written.