### PR TITLE
Add embodied emissions to storage

### DIFF
--- a/docs/src/comparison.md
+++ b/docs/src/comparison.md
@@ -33,7 +33,7 @@ SPRUCE is part of a growing ecosystem of open source tools focused on measuring 
 | **Data Privacy**       | Processes data locally, no external API calls for core functionality | Requires cloud provider credentials                   |
 | **Modularity**         | Highly modular with configurable enrichment pipelines                | Fixed calculation pipeline with configuration options |
 | **Output**             | Enriched Parquet/CSV files for custom analytics and visualization    | Pre-built dashboard and recommendations               |
-| **Embodied Carbon**    | Includes embodied emissions via Boavizta integration                 | Limited embodied carbon estimates                     |
+| **Embodied Carbon**    | Includes embodied emissions for compute via Boavizta, and for storage from drive LCAs | Limited embodied carbon estimates                     |
 | **Scalability**        | Designed for large-scale data processing with Apache Spark           | Suitable for smaller to medium deployments            |
 | **Carbon Intensity**   | Uses Ember average data                                              | Default factors outdated                              |
 | **Maintenance Status** | Actively maintained with regular updates                             | No longer actively maintained                         |

--- a/docs/src/methodology.md
+++ b/docs/src/methodology.md
@@ -1,6 +1,6 @@
 ---
 title: "How cloud carbon and water estimates are calculated"
-description: "The methodology behind SPRUCE: embodied emissions from Boavizta, energy models from Cloud Carbon Footprint, Ember grid carbon intensity, PUE and WUE."
+description: "The methodology behind SPRUCE: embodied emissions from Boavizta and drive LCAs, energy models from Cloud Carbon Footprint, Ember grid carbon intensity, PUE and WUE."
 ---
 
 # How SPRUCE calculates cloud carbon, energy and water estimates
@@ -30,7 +30,7 @@ The main columns added by SPRUCE are:
 : emissions of CO2 eq in grams from the energy usage.
 
 `embodied_emissions_co2eq_g`
-: emissions of CO2 eq in grams embodied in the hardware used by the service, i.e. how much did it take to produce it.
+: emissions of CO2 eq in grams embodied in the hardware used by the service, i.e. how much did it take to produce it. Estimated for compute instances, LLM inference, and the drives behind storage; other services leave it null rather than zero.
 
 The total emissions for a service are `operational_emissions_co2eq_g` + `embodied_emissions_co2eq_g`.
 

--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -84,7 +84,7 @@ from their provisioned capacity.
 | | |
 |---|---|
 | **Classes** | `com.digitalpebble.spruce.modules.ccf.aws.Storage`<br>`com.digitalpebble.spruce.modules.ccf.azure.Storage` |
-| **Writes** | `operational_energy_kwh`<br>`embodied_emissions_co2eq_g` (AWS only) |
+| **Writes** | `operational_energy_kwh`<br>`embodied_emissions_co2eq_g` |
 
 **Energy configuration** (in Wh per TB-hour):
 
@@ -93,7 +93,7 @@ from their provisioned capacity.
 | `hdd_coefficient_tb_h` | 0.65 | Energy per TB-hour for HDD storage |
 | `ssd_coefficient_tb_h` | 1.2  | Energy per TB-hour for SSD storage |
 
-**Embodied emissions configuration** (AWS only):
+**Embodied emissions configuration**:
 
 | Key | Default | Description |
 |---|---|---|
@@ -108,7 +108,8 @@ capacity, so its figure is a rate per GB. The defaults work out at 0.40 kg CO2eq
 HDD and 11 kg for SSD. The 30 kg per drive is where Boavizta, a Seagate Exos X22 LCA, Seagate's
 published per-TB-year figure and a meta-analysis of 24 vendor LCAs converge; the 0.055 kg/GB is
 where Boavizta's die-area formula and a 2025 3D NAND study agree. The 15 TB drive is the
-installed-fleet average from Backblaze's 2025 Drive Stats. See
+installed-fleet average from Backblaze's 2025 Drive Stats, and describes the physical drive
+rather than a provisioned volume, so it is not the same thing as an Azure Managed Disk size. See
 [issue #102](https://github.com/DigitalPebble/spruce/issues/102) for the full derivation.
 
 ### Networking

--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -84,14 +84,32 @@ from their provisioned capacity.
 | | |
 |---|---|
 | **Classes** | `com.digitalpebble.spruce.modules.ccf.aws.Storage`<br>`com.digitalpebble.spruce.modules.ccf.azure.Storage` |
-| **Writes** | `operational_energy_kwh` |
+| **Writes** | `operational_energy_kwh`<br>`embodied_emissions_co2eq_g` (AWS only) |
 
-**Configuration** (in Wh per TB-hour):
+**Energy configuration** (in Wh per TB-hour):
 
 | Key | Default | Description |
 |---|---|---|
 | `hdd_coefficient_tb_h` | 0.65 | Energy per TB-hour for HDD storage |
 | `ssd_coefficient_tb_h` | 1.2  | Energy per TB-hour for SSD storage |
+
+**Embodied emissions configuration** (AWS only):
+
+| Key | Default | Description |
+|---|---|---|
+| `hdd_embodied_kg_per_drive` | 30.0 | Embodied emissions of one hard drive, in kg CO2eq |
+| `hdd_capacity_gb` | 15000.0 | Capacity assumed for one hard drive |
+| `ssd_embodied_kg_per_gb` | 0.055 | Embodied emissions of an SSD, per GB of capacity |
+| `storage_lifetime_hours` | 43800.0 | Service life the embodied emissions are amortised over (5 years) |
+
+A hard drive costs roughly the same to manufacture whatever its capacity, so its embodied
+emissions are a constant per drive divided by the assumed capacity; an SSD's die area scales with
+capacity, so its figure is a rate per GB. The defaults work out at 0.40 kg CO2eq per TB-year for
+HDD and 11 kg for SSD. The 30 kg per drive is where Boavizta, a Seagate Exos X22 LCA, Seagate's
+published per-TB-year figure and a meta-analysis of 24 vendor LCAs converge; the 0.055 kg/GB is
+where Boavizta's die-area formula and a 2025 3D NAND study agree. The 15 TB drive is the
+installed-fleet average from Backblaze's 2025 Drive Stats. See
+[issue #102](https://github.com/DigitalPebble/spruce/issues/102) for the full derivation.
 
 ### Networking
 

--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -43,7 +43,7 @@ flowchart LR
 | Module | Providers | Writes | Based on |
 |---|---|---|---|
 | [RegionExtraction](#regionextraction) | AWS, Azure, FOCUS | `region` | — |
-| [Storage](#storage) | AWS, Azure | `operational_energy_kwh` | [Cloud Carbon Footprint](https://www.cloudcarbonfootprint.org/) |
+| [Storage](#storage) | AWS, Azure | `operational_energy_kwh`, `embodied_emissions_co2eq_g` | [Cloud Carbon Footprint](https://www.cloudcarbonfootprint.org/) for energy, [Boavizta](https://doc.api.boavizta.org/) and vendor LCAs for embodied |
 | [Networking](#networking) | AWS, Azure | `operational_energy_kwh` | [Boavizta](https://boavizta.org/) coefficients |
 | [Serverless](#serverless) | AWS | `operational_energy_kwh` | [Tailpipe](https://tailpipe.ai/methodology/serverless-explained/) |
 | [Accelerators](#accelerators) | AWS | `operational_energy_kwh` | [Cloud Carbon Footprint](https://www.cloudcarbonfootprint.org/) |
@@ -70,16 +70,17 @@ provider-neutral: it reads the standard `RegionId` column.
 
 ## Stage 2 — Energy and embodied estimates
 
-The modules in this stage estimate the energy used by a row of usage — and, for Boavizta
-and EcoLogits, the related embodied emissions. Each module handles a different kind of
+The modules in this stage estimate the energy used by a row of usage and, for Storage,
+Boavizta and EcoLogits, the related embodied emissions. Each module handles a different kind of
 usage (storage, networking, compute, …), so they complement each other rather than overlap.
 
 ### Storage
 
 Estimates the energy used for storage by applying a flat coefficient per GB, following the
-approach of the [Cloud Carbon Footprint](https://www.cloudcarbonfootprint.org/docs/methodology#storage) project.
-Service-specific replication factors are applied. On Azure, managed disks are estimated
-from their provisioned capacity.
+approach of the [Cloud Carbon Footprint](https://www.cloudcarbonfootprint.org/docs/methodology#storage) project,
+and the embodied emissions of the drives holding the data, amortised over their service life.
+Service-specific replication factors are applied to both, since the same bytes occupy that many
+times more physical drives. On Azure, managed disks are estimated from their provisioned capacity.
 
 | | |
 |---|---|
@@ -102,14 +103,31 @@ from their provisioned capacity.
 | `ssd_embodied_kg_per_gb` | 0.055 | Embodied emissions of an SSD, per GB of capacity |
 | `storage_lifetime_hours` | 43800.0 | Service life the embodied emissions are amortised over (5 years) |
 
-A hard drive costs roughly the same to manufacture whatever its capacity, so its embodied
-emissions are a constant per drive divided by the assumed capacity; an SSD's die area scales with
-capacity, so its figure is a rate per GB. The defaults work out at 0.40 kg CO2eq per TB-year for
-HDD and 11 kg for SSD. The 30 kg per drive is where Boavizta, a Seagate Exos X22 LCA, Seagate's
-published per-TB-year figure and a meta-analysis of 24 vendor LCAs converge; the 0.055 kg/GB is
-where Boavizta's die-area formula and a 2025 3D NAND study agree. The 15 TB drive is the
-installed-fleet average from Backblaze's 2025 Drive Stats, and describes the physical drive
-rather than a provisioned volume, so it is not the same thing as an Azure Managed Disk size. See
+The two media are modelled on different bases. A hard drive costs roughly the same to manufacture
+whatever its capacity, since the platters, motor, actuator, casing and PCB are near-fixed for a
+3.5" unit and areal density does the work, so its embodied emissions are a constant per drive
+divided by an assumed capacity. An SSD's die area scales with capacity, so its figure is a rate
+per GB. With the defaults that works out at 0.40 kg CO2eq per TB-year for HDD and 11 kg for SSD.
+
+Note that `hdd_capacity_gb` describes the physical drive rather than a provisioned volume, so it
+is not the same thing as an Azure Managed Disk size or an EBS volume size.
+
+**Data sources for the embodied figures**:
+
+| Figure | Value | Source |
+|---|---|---|
+| HDD, per drive | 31.11 kg CO2eq | [BoaviztAPI HDD component](https://doc.api.boavizta.org/Explanations/components/hdd/), from [Umweltbundesamt, *Green Cloud Computing* 2021](https://www.umweltbundesamt.de/sites/default/files/medien/5750/publikationen/2021-06-17_texte_94-2021_green-cloud-computing.pdf) |
+| HDD, Seagate Exos X22 LCA | 28.7 kg CO2eq for a 22 TB drive | [Tailpipe manufacture methodology](https://tailpipe.ai/methodology/embodied-emissions-methodology-manufacture/) |
+| HDD, per TB-year | 0.27 kg CO2eq | [Seagate, hard drives and data centre sustainability](https://www.seagate.com/blog/hard-drives-the-key-to-data-center-sustainability/) |
+| HDD, 24 vendor LCAs | 0.02 kg CO2eq/GB over a 512 GB to 6 TB sample | [Tannu &amp; Nair, *The Dirty Secret of SSDs: Embodied Carbon*](https://arxiv.org/pdf/2207.10793) |
+| SSD, die-area formula | 0.052 kg CO2eq/GB | [BoaviztAPI SSD component](https://doc.api.boavizta.org/Explanations/components/ssd/) |
+| SSD, 3D NAND study | 0.056 kg CO2eq/GB | [Tailpipe manufacture methodology](https://tailpipe.ai/methodology/embodied-emissions-methodology-manufacture/), from [*Embodied Carbon Footprint of 3D NAND Memories*](https://hal.science/hal-05015578v1/document) |
+| Drive capacity mix | 15 TB installed-fleet average | [Backblaze Drive Stats 2025](https://www.backblaze.com/blog/backblaze-drive-stats-for-2025/) |
+
+The first four rows converge on roughly 30 kg per drive across a 40x range of capacities, which
+is itself the evidence for treating HDD embodied carbon as capacity independent. The Tannu &amp;
+Nair rate cannot be applied per GB to current hardware: it encodes the drive sizes of a pre-2023
+corpus and overstates per-byte embodied carbon by about an order of magnitude. See
 [issue #102](https://github.com/DigitalPebble/spruce/issues/102) for the full derivation.
 
 ### Networking

--- a/src/main/java/com/digitalpebble/spruce/Utils.java
+++ b/src/main/java/com/digitalpebble/spruce/Utils.java
@@ -108,6 +108,20 @@ public abstract class Utils {
     }
 
     /**
+     * Reads a numeric module parameter, tolerating the whole-number literals JSON configs
+     * routinely carry as integers rather than doubles.
+     *
+     * @param params module configuration
+     * @param key    parameter name
+     * @param fallback value returned when the parameter is absent
+     * @return the configured value, or {@code fallback}
+     */
+    public static double doubleParam(Map<String, Object> params, String key, double fallback) {
+        Number value = (Number) params.get(key);
+        return value != null ? value.doubleValue() : fallback;
+    }
+
+    /**
      * Utility conversions used throughout the codebase.
      *
      * <p>Contains helper methods to convert between different units of usage.

--- a/src/main/java/com/digitalpebble/spruce/modules/ccf/aws/Storage.java
+++ b/src/main/java/com/digitalpebble/spruce/modules/ccf/aws/Storage.java
@@ -133,10 +133,10 @@ public class Storage implements EnrichmentModule {
             ssd_gb_coefficient = coef / 1024d;
         }
 
-        hdd_embodied_kg_per_drive = doubleParam(params, "hdd_embodied_kg_per_drive", hdd_embodied_kg_per_drive);
-        hdd_capacity_gb = doubleParam(params, "hdd_capacity_gb", hdd_capacity_gb);
-        ssd_embodied_kg_per_gb = doubleParam(params, "ssd_embodied_kg_per_gb", ssd_embodied_kg_per_gb);
-        storage_lifetime_hours = doubleParam(params, "storage_lifetime_hours", storage_lifetime_hours);
+        hdd_embodied_kg_per_drive = Utils.doubleParam(params, "hdd_embodied_kg_per_drive", hdd_embodied_kg_per_drive);
+        hdd_capacity_gb = Utils.doubleParam(params, "hdd_capacity_gb", hdd_capacity_gb);
+        ssd_embodied_kg_per_gb = Utils.doubleParam(params, "ssd_embodied_kg_per_gb", ssd_embodied_kg_per_gb);
+        storage_lifetime_hours = Utils.doubleParam(params, "storage_lifetime_hours", storage_lifetime_hours);
 
         hdd_embodied_g_per_gb_hour =
                 hdd_embodied_kg_per_drive * 1000d / (hdd_capacity_gb * storage_lifetime_hours);
@@ -168,12 +168,6 @@ public class Storage implements EnrichmentModule {
     @Override
     public Column[] columnsAdded() {
         return new Column[]{ENERGY_USED, EMBODIED_EMISSIONS};
-    }
-
-    /** Reads a numeric parameter, tolerating the integer literals JSON configs often carry. */
-    private static double doubleParam(Map<String, Object> params, String key, double fallback) {
-        Number value = (Number) params.get(key);
-        return value != null ? value.doubleValue() : fallback;
     }
 
     @Override

--- a/src/main/java/com/digitalpebble/spruce/modules/ccf/aws/Storage.java
+++ b/src/main/java/com/digitalpebble/spruce/modules/ccf/aws/Storage.java
@@ -18,12 +18,38 @@ import java.util.List;
 import java.util.Map;
 
 import static com.digitalpebble.spruce.CURColumn.*;
+import static com.digitalpebble.spruce.SpruceColumn.EMBODIED_EMISSIONS;
 import static com.digitalpebble.spruce.SpruceColumn.ENERGY_USED;
 import static com.digitalpebble.spruce.Utils.loadJSONResources;
 
 /**
- * Provides an estimate of energy used for storage.
- * Applies a flat coefficient per Gb
+ * Provides an estimate of energy used for storage, and of the embodied emissions of the drives
+ * holding it. Applies a flat coefficient per Gb
+ *
+ * <p>Embodied emissions are amortised over a five year service life. The two media are modelled
+ * on different bases because they behave differently: a hard drive costs roughly the same to
+ * manufacture whatever its capacity, since the platters, motor, actuator, casing and PCB are
+ * near-fixed for a 3.5" unit and areal density does the work, whereas an SSD's die area scales
+ * with capacity. Hence a constant per drive for HDD and a rate per GB for SSD.
+ *
+ * <p>The 30 kg CO2eq per drive is the convergence point of four independent sources spanning a
+ * 40x range of drive capacities, which is itself the evidence for treating it as capacity
+ * independent: Boavizta / Umweltbundesamt <i>Green Cloud Computing</i> 2021 (31.11 kg per unit),
+ * a Seagate Exos X22 LCA (28.7 kg for a 22 TB drive), Seagate's published 0.27 kg per TB-year,
+ * and Tannu &amp; Nair's meta-analysis of 24 vendor LCAs (0.02 kg/GB over a 512 GB to 6 TB
+ * sample). Note that the last of those cannot be used as a per-GB rate on modern hardware: it
+ * encodes the drive sizes of a pre-2023 corpus and overstates current per-byte embodied carbon
+ * by an order of magnitude.
+ *
+ * <p>The 0.055 kg CO2eq per GB for SSD is where Boavizta's die-area formula (0.052) and the 2025
+ * <i>Embodied Carbon Footprint of 3D NAND Memories</i> study (0.056) agree. Tannu &amp; Nair's
+ * 0.16 kg/GB is roughly 3x higher because 3D NAND layer scaling has cut per-GB manufacturing
+ * carbon since their corpus closed.
+ *
+ * <p>The assumed 15 TB drive is the installed-fleet average implied by Backblaze's 2025 Drive
+ * Stats, which is the right basis for bytes sitting on hardware bought over several years;
+ * current nearline shipments average nearer 22 TB, which would give 0.27 kg per TB-year instead
+ * of 0.40. Both figures are configurable.
  *
  * <p>The values read (operations, usage types, units) are identical in CUR and FOCUS reports,
  * only the column labels differ: {@link #bindReportFormat(ReportFormat)} selects the bindings.
@@ -32,6 +58,13 @@ import static com.digitalpebble.spruce.Utils.loadJSONResources;
  *
  * @see <a href="https://www.cloudcarbonfootprint.org/docs/methodology#storage">CCF methodology</a>
  * @see <a href="https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/blob/9f2cf436e5ad020830977e52c3b0a1719d20a8b9/packages/aws/src/lib/CostAndUsageTypes.ts#L25">resource file</a>
+ * @see <a href="https://doc.api.boavizta.org/Explanations/components/hdd/">Boavizta HDD embodied impacts</a>
+ * @see <a href="https://doc.api.boavizta.org/Explanations/components/ssd/">Boavizta SSD embodied impacts</a>
+ * @see <a href="https://tailpipe.ai/methodology/embodied-emissions-methodology-manufacture/">Tailpipe manufacture methodology, incl. the Exos X22 LCA</a>
+ * @see <a href="https://www.seagate.com/blog/hard-drives-the-key-to-data-center-sustainability/">Seagate, embodied carbon per TB-year</a>
+ * @see <a href="https://arxiv.org/pdf/2207.10793">Tannu &amp; Nair, The Dirty Secret of SSDs: Embodied Carbon</a>
+ * @see <a href="https://www.backblaze.com/blog/backblaze-drive-stats-for-2025/">Backblaze Drive Stats 2025, fleet capacity mix</a>
+ * @see <a href="https://github.com/DigitalPebble/spruce/issues/102">issue #102</a>
  **/
 public class Storage implements EnrichmentModule {
 
@@ -69,6 +102,20 @@ public class Storage implements EnrichmentModule {
     //  1.2 Watt-Hours per Terabyte-Hour for SSD
     double ssd_gb_coefficient = 1.2 / 1024d;
 
+    /** Embodied emissions of one hard drive, in kg CO2eq; see the class javadoc for why this is
+     *  a constant per drive rather than a rate per byte. */
+    double hdd_embodied_kg_per_drive = 30d;
+    /** Capacity assumed for one hard drive, in GB. */
+    double hdd_capacity_gb = 15_000d;
+    /** Embodied emissions of an SSD, in kg CO2eq per GB of capacity. */
+    double ssd_embodied_kg_per_gb = 0.055d;
+    /** Service life over which embodied emissions are amortised, in hours (5 years). */
+    double storage_lifetime_hours = 43_800d;
+
+    /** Grams CO2eq per GB-hour of stored data, derived in {@link #init(Map)}. */
+    double hdd_embodied_g_per_gb_hour;
+    double ssd_embodied_g_per_gb_hour;
+
     List<String> ssd_usage_types;
     List<String> hdd_usage_types;
     List<String> ssd_services;
@@ -86,8 +133,19 @@ public class Storage implements EnrichmentModule {
             ssd_gb_coefficient = coef / 1024d;
         }
 
+        hdd_embodied_kg_per_drive = doubleParam(params, "hdd_embodied_kg_per_drive", hdd_embodied_kg_per_drive);
+        hdd_capacity_gb = doubleParam(params, "hdd_capacity_gb", hdd_capacity_gb);
+        ssd_embodied_kg_per_gb = doubleParam(params, "ssd_embodied_kg_per_gb", ssd_embodied_kg_per_gb);
+        storage_lifetime_hours = doubleParam(params, "storage_lifetime_hours", storage_lifetime_hours);
+
+        hdd_embodied_g_per_gb_hour =
+                hdd_embodied_kg_per_drive * 1000d / (hdd_capacity_gb * storage_lifetime_hours);
+        ssd_embodied_g_per_gb_hour = ssd_embodied_kg_per_gb * 1000d / storage_lifetime_hours;
+
         log.info("hdd_gb_coefficient: {}", hdd_gb_coefficient);
         log.info("ssd_gb_coefficient: {}", ssd_gb_coefficient);
+        log.info("hdd_embodied_g_per_gb_hour: {}", hdd_embodied_g_per_gb_hour);
+        log.info("ssd_embodied_g_per_gb_hour: {}", ssd_embodied_g_per_gb_hour);
 
         try {
             Map<String, Object> map = loadJSONResources("ccf/storage.json");
@@ -109,7 +167,13 @@ public class Storage implements EnrichmentModule {
 
     @Override
     public Column[] columnsAdded() {
-        return new Column[]{ENERGY_USED};
+        return new Column[]{ENERGY_USED, EMBODIED_EMISSIONS};
+    }
+
+    /** Reads a numeric parameter, tolerating the integer literals JSON configs often carry. */
+    private static double doubleParam(Map<String, Object> params, String key, double fallback) {
+        Number value = (Number) params.get(key);
+        return value != null ? value.doubleValue() : fallback;
     }
 
     @Override
@@ -180,6 +244,10 @@ public class Storage implements EnrichmentModule {
         //  to kwh
         double energy_kwh = amount /1000 * coefficient * replication;
         enrichedValues.put(ENERGY_USED, energy_kwh);
+        // the replication factor applies to the hardware as well as to the energy: the same bytes
+        // occupy that many times more physical drives, and so that much more embodied carbon
+        double embodied_coefficient = isHDD ? hdd_embodied_g_per_gb_hour : ssd_embodied_g_per_gb_hour;
+        enrichedValues.put(EMBODIED_EMISSIONS, amount * embodied_coefficient * replication);
     }
 
     /**

--- a/src/main/java/com/digitalpebble/spruce/modules/ccf/azure/Storage.java
+++ b/src/main/java/com/digitalpebble/spruce/modules/ccf/azure/Storage.java
@@ -21,14 +21,26 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static com.digitalpebble.spruce.SpruceColumn.EMBODIED_EMISSIONS;
 import static com.digitalpebble.spruce.SpruceColumn.ENERGY_USED;
 
 /**
- * Provides an estimate of energy used for Azure storage capacity meters.
+ * Provides an estimate of energy used for Azure storage capacity meters, and of the embodied
+ * emissions of the drives holding the data.
  * The values read (meter names, units) are identical in legacy and FOCUS reports, only the
  * column labels differ: {@link #bindReportFormat(ReportFormat)} selects the bindings.
  *
+ * <p>The embodied emissions coefficients and their derivation are the same as for AWS, since they
+ * describe drives rather than anything provider specific; see
+ * {@link com.digitalpebble.spruce.modules.ccf.aws.Storage} for the sources and the reasoning
+ * behind modelling HDD per drive and SSD per GB.
+ *
+ * <p>Note that {@code hdd_capacity_gb} describes the physical drive, not a Managed Disk SKU. The
+ * provisioned size of a P10 or S4 volume says nothing about the drive underneath it, so the
+ * capacities in {@code MANAGED_DISKS} must not be substituted here.
+ *
  * @see <a href="https://www.cloudcarbonfootprint.org/docs/methodology#storage">CCF methodology</a>
+ * @see <a href="https://github.com/DigitalPebble/spruce/issues/102">issue #102</a>
  **/
 public class Storage implements EnrichmentModule {
 
@@ -72,6 +84,20 @@ public class Storage implements EnrichmentModule {
     //  1.2 Watt-Hours per Terabyte-Hour for SSD
     double ssd_gb_coefficient = 1.2 / 1024d;
 
+    /** Embodied emissions of one hard drive, in kg CO2eq; a constant per drive rather than a
+     *  rate per byte. */
+    double hdd_embodied_kg_per_drive = 30d;
+    /** Capacity assumed for one physical hard drive, in GB. */
+    double hdd_capacity_gb = 15_000d;
+    /** Embodied emissions of an SSD, in kg CO2eq per GB of capacity. */
+    double ssd_embodied_kg_per_gb = 0.055d;
+    /** Service life over which embodied emissions are amortised, in hours (5 years). */
+    double storage_lifetime_hours = 43_800d;
+
+    /** Grams CO2eq per GB-hour of stored data, derived in {@link #init(Map)}. */
+    double hdd_embodied_g_per_gb_hour;
+    double ssd_embodied_g_per_gb_hour;
+
     @Override
     @SuppressWarnings("unchecked")
     public void init(Map<String, Object> params) {
@@ -84,8 +110,19 @@ public class Storage implements EnrichmentModule {
             ssd_gb_coefficient = coef / 1024d;
         }
 
+        hdd_embodied_kg_per_drive = Utils.doubleParam(params, "hdd_embodied_kg_per_drive", hdd_embodied_kg_per_drive);
+        hdd_capacity_gb = Utils.doubleParam(params, "hdd_capacity_gb", hdd_capacity_gb);
+        ssd_embodied_kg_per_gb = Utils.doubleParam(params, "ssd_embodied_kg_per_gb", ssd_embodied_kg_per_gb);
+        storage_lifetime_hours = Utils.doubleParam(params, "storage_lifetime_hours", storage_lifetime_hours);
+
+        hdd_embodied_g_per_gb_hour =
+                hdd_embodied_kg_per_drive * 1000d / (hdd_capacity_gb * storage_lifetime_hours);
+        ssd_embodied_g_per_gb_hour = ssd_embodied_kg_per_gb * 1000d / storage_lifetime_hours;
+
         LOG.info("hdd_gb_coefficient: {}", hdd_gb_coefficient);
         LOG.info("ssd_gb_coefficient: {}", ssd_gb_coefficient);
+        LOG.info("hdd_embodied_g_per_gb_hour: {}", hdd_embodied_g_per_gb_hour);
+        LOG.info("ssd_embodied_g_per_gb_hour: {}", ssd_embodied_g_per_gb_hour);
 
         try {
             Map<String, Object> map = Utils.loadJSONResources("ccf/azure-storage.json");
@@ -106,7 +143,7 @@ public class Storage implements EnrichmentModule {
 
     @Override
     public Column[] columnsAdded() {
-        return new Column[]{ENERGY_USED};
+        return new Column[]{ENERGY_USED, EMBODIED_EMISSIONS};
     }
 
     @Override
@@ -212,6 +249,10 @@ public class Storage implements EnrichmentModule {
         double coefficient = isHDD ? hdd_gb_coefficient : ssd_gb_coefficient;
         double energyKwh = gbHours / 1000 * coefficient * replication;
         enrichedValues.put(ENERGY_USED, energyKwh);
+        // the replication factor applies to the hardware as well as to the energy: the same bytes
+        // occupy that many times more physical drives, and so that much more embodied carbon
+        double embodiedCoefficient = isHDD ? hdd_embodied_g_per_gb_hour : ssd_embodied_g_per_gb_hour;
+        enrichedValues.put(EMBODIED_EMISSIONS, gbHours * embodiedCoefficient * replication);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/resources/default-config-aws-focus.json
+++ b/src/main/resources/default-config-aws-focus.json
@@ -7,7 +7,11 @@
       "className": "com.digitalpebble.spruce.modules.ccf.aws.Storage",
       "config": {
         "hdd_coefficient_tb_h": 0.65,
-        "ssd_coefficient_tb_h": 1.2
+        "ssd_coefficient_tb_h": 1.2,
+        "hdd_embodied_kg_per_drive": 30.0,
+        "hdd_capacity_gb": 15000.0,
+        "ssd_embodied_kg_per_gb": 0.055,
+        "storage_lifetime_hours": 43800.0
       }
     },
     {

--- a/src/main/resources/default-config-aws.json
+++ b/src/main/resources/default-config-aws.json
@@ -7,7 +7,11 @@
       "className": "com.digitalpebble.spruce.modules.ccf.aws.Storage",
       "config": {
         "hdd_coefficient_tb_h": 0.65,
-        "ssd_coefficient_tb_h": 1.2
+        "ssd_coefficient_tb_h": 1.2,
+        "hdd_embodied_kg_per_drive": 30.0,
+        "hdd_capacity_gb": 15000.0,
+        "ssd_embodied_kg_per_gb": 0.055,
+        "storage_lifetime_hours": 43800.0
       }
     },
     {

--- a/src/main/resources/default-config-azure-focus.json
+++ b/src/main/resources/default-config-azure-focus.json
@@ -7,7 +7,11 @@
       "className": "com.digitalpebble.spruce.modules.ccf.azure.Storage",
       "config": {
         "hdd_coefficient_tb_h": 0.65,
-        "ssd_coefficient_tb_h": 1.2
+        "ssd_coefficient_tb_h": 1.2,
+        "hdd_embodied_kg_per_drive": 30.0,
+        "hdd_capacity_gb": 15000.0,
+        "ssd_embodied_kg_per_gb": 0.055,
+        "storage_lifetime_hours": 43800.0
       }
     },
     {

--- a/src/main/resources/default-config-azure.json
+++ b/src/main/resources/default-config-azure.json
@@ -7,7 +7,11 @@
       "className": "com.digitalpebble.spruce.modules.ccf.azure.Storage",
       "config": {
         "hdd_coefficient_tb_h": 0.65,
-        "ssd_coefficient_tb_h": 1.2
+        "ssd_coefficient_tb_h": 1.2,
+        "hdd_embodied_kg_per_drive": 30.0,
+        "hdd_capacity_gb": 15000.0,
+        "ssd_embodied_kg_per_gb": 0.055,
+        "storage_lifetime_hours": 43800.0
       }
     },
     {

--- a/src/test/java/com/digitalpebble/spruce/modules/ccf/aws/StorageTest.java
+++ b/src/test/java/com/digitalpebble/spruce/modules/ccf/aws/StorageTest.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import static com.digitalpebble.spruce.SpruceColumn.EMBODIED_EMISSIONS;
 import static com.digitalpebble.spruce.SpruceColumn.ENERGY_USED;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -40,7 +41,8 @@ class StorageTest {
     private static Stream<Arguments> provideArgsWithType() {
         return Stream.of(
             Arguments.of("Storage", 0.1d, "EUW2-TimedStorage-ByteHrs", "AmazonS3", "GB-Mo", false),
-            Arguments.of("Storage", 0.1d, "SomeUsageType", "AmazonDocDB", "GB-Mo", false),
+            // AmazonDocDB is in SSD_SERVICES, so it takes the SSD coefficients
+            Arguments.of("Storage", 0.1d, "SomeUsageType", "AmazonDocDB", "GB-Mo", true),
             Arguments.of("CreateVolume", 10d, "EUW2-EBS:VolumeUsage", "AmazonEC2", "GB-Mo", false),
             Arguments.of("CreateVolume-Gp2", 10d, "EBS:VolumeUsage.gp2", "AmazonEC2", "GB-Mo", true),
             Arguments.of("CreateVolume-Gp3", 10d, "VolumeUsage.gp3", "AmazonEC2", "GB-Mo", true)
@@ -66,7 +68,54 @@ class StorageTest {
         int replication = storage.getReplicationFactor(service, usage);
         double coef = isSSD ? storage.ssd_gb_coefficient : storage.hdd_gb_coefficient;
         double expected = gb_hours * coef * replication / 1000;
-        assertEquals(expected, (Double) enriched.get(ENERGY_USED), 0.0001);
+        assertEquals(expected, (Double) enriched.get(ENERGY_USED), 1e-12);
+
+        double embodiedCoef = isSSD ? storage.ssd_embodied_g_per_gb_hour : storage.hdd_embodied_g_per_gb_hour;
+        double expectedEmbodied = gb_hours * embodiedCoef * replication;
+        assertEquals(expectedEmbodied, (Double) enriched.get(EMBODIED_EMISSIONS), 0.0001);
+    }
+
+    /** A row the module does not recognise gets neither impact, not a zero for one of them. */
+    @ParameterizedTest
+    @MethodSource("provideArgsWrongUnit")
+    void noEmbodiedWithoutEnergy(String operation, double amount, String usage, String service, String unit) {
+        Object[] values = new Object[]{operation, amount, usage, service, unit, null};
+        Row row = new GenericRowWithSchema(values, schema);
+        Map<Column, Object> enriched = new HashMap<>();
+        storage.enrich(row, enriched);
+        assertFalse(enriched.containsKey(EMBODIED_EMISSIONS));
+    }
+
+    /**
+     * HDD embodied carbon is a constant per drive spread over the drive's capacity and life,
+     * SSD a rate per GB spread over its life. Defaults: 30 kg per 15 TB drive and 0.055 kg/GB,
+     * both over 43800 hours.
+     */
+    @Test
+    void embodiedCoefficientsDerivedFromDefaults() {
+        assertEquals(30_000d / (15_000d * 43_800d), storage.hdd_embodied_g_per_gb_hour, 1e-12);
+        assertEquals(55d / 43_800d, storage.ssd_embodied_g_per_gb_hour, 1e-12);
+    }
+
+    /** The drive size and life are assumptions, so they have to be overridable. */
+    @Test
+    void embodiedCoefficientsHonourConfig() {
+        Storage configured = new Storage();
+        configured.init(Map.of(
+                "hdd_embodied_kg_per_drive", 28.7d,
+                "hdd_capacity_gb", 22_000d,
+                "ssd_embodied_kg_per_gb", 0.052d,
+                "storage_lifetime_hours", 49_932d));
+        assertEquals(28_700d / (22_000d * 49_932d), configured.hdd_embodied_g_per_gb_hour, 1e-12);
+        assertEquals(52d / 49_932d, configured.ssd_embodied_g_per_gb_hour, 1e-12);
+    }
+
+    /** JSON configs routinely carry whole numbers as integers rather than doubles. */
+    @Test
+    void embodiedConfigAcceptsIntegerLiterals() {
+        Storage configured = new Storage();
+        configured.init(Map.of("hdd_embodied_kg_per_drive", 30, "hdd_capacity_gb", 15000));
+        assertEquals(30_000d / (15_000d * 43_800d), configured.hdd_embodied_g_per_gb_hour, 1e-12);
     }
 
     @ParameterizedTest
@@ -126,6 +175,8 @@ class StorageTest {
             int replication = focusStorage.getReplicationFactor("AmazonS3", "TimedStorage-ByteHrs");
             double expected = gb_hours * focusStorage.hdd_gb_coefficient * replication / 1000;
             assertEquals(expected, (Double) enriched.get(ENERGY_USED), 0.0001);
+            assertEquals(gb_hours * focusStorage.hdd_embodied_g_per_gb_hour * replication,
+                    (Double) enriched.get(EMBODIED_EMISSIONS), 0.0001);
         }
 
         @Test

--- a/src/test/java/com/digitalpebble/spruce/modules/ccf/azure/StorageTest.java
+++ b/src/test/java/com/digitalpebble/spruce/modules/ccf/azure/StorageTest.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import static com.digitalpebble.spruce.SpruceColumn.EMBODIED_EMISSIONS;
 import static com.digitalpebble.spruce.SpruceColumn.ENERGY_USED;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -83,7 +84,9 @@ class StorageTest {
                             double quantity, double gbHours, int replication, boolean isHDD) {
         Map<Column, Object> enriched = enrich(row(meterCategory, meterSubCategory, meterName, unit, quantity));
         double expected = expected(gbHours, replication, isHDD);
-        assertEquals(expected, (Double) enriched.get(ENERGY_USED), 0.0001);
+        assertEquals(expected, (Double) enriched.get(ENERGY_USED), 1e-12);
+        assertEquals(expectedEmbodied(gbHours, replication, isHDD),
+                (Double) enriched.get(EMBODIED_EMISSIONS), 1e-12);
     }
 
     @ParameterizedTest
@@ -92,6 +95,31 @@ class StorageTest {
                             Double quantity) {
         Map<Column, Object> enriched = enrich(row(meterCategory, meterSubCategory, meterName, unit, quantity));
         assertFalse(enriched.containsKey(ENERGY_USED));
+        assertFalse(enriched.containsKey(EMBODIED_EMISSIONS));
+    }
+
+    /**
+     * HDD embodied carbon is a constant per drive spread over the drive's capacity and life, SSD
+     * a rate per GB spread over its life. Defaults match the AWS module: 30 kg per 15 TB drive
+     * and 0.055 kg/GB, both over 43800 hours.
+     */
+    @Test
+    void embodiedCoefficientsDerivedFromDefaults() {
+        assertEquals(30_000d / (15_000d * 43_800d), storage.hdd_embodied_g_per_gb_hour, 1e-12);
+        assertEquals(55d / 43_800d, storage.ssd_embodied_g_per_gb_hour, 1e-12);
+    }
+
+    /** The drive size and life are assumptions, so they have to be overridable. */
+    @Test
+    void embodiedCoefficientsHonourConfig() {
+        Storage configured = new Storage();
+        configured.init(Map.of(
+                "hdd_embodied_kg_per_drive", 28.7d,
+                "hdd_capacity_gb", 22_000d,
+                "ssd_embodied_kg_per_gb", 0.052d,
+                "storage_lifetime_hours", 49_932d));
+        assertEquals(28_700d / (22_000d * 49_932d), configured.hdd_embodied_g_per_gb_hour, 1e-12);
+        assertEquals(52d / 49_932d, configured.ssd_embodied_g_per_gb_hour, 1e-12);
     }
 
     private Row row(String meterCategory, String meterSubCategory, String meterName, String unit, Double quantity) {
@@ -108,6 +136,11 @@ class StorageTest {
     private double expected(double gbHours, int replication, boolean isHDD) {
         double coefficient = isHDD ? storage.hdd_gb_coefficient : storage.ssd_gb_coefficient;
         return gbHours / 1000 * coefficient * replication;
+    }
+
+    private double expectedEmbodied(double gbHours, int replication, boolean isHDD) {
+        double coefficient = isHDD ? storage.hdd_embodied_g_per_gb_hour : storage.ssd_embodied_g_per_gb_hour;
+        return gbHours * coefficient * replication;
     }
 
     /**
@@ -144,13 +177,16 @@ class StorageTest {
             Map<Column, Object> enriched = enrich(row("Storage", "Tables", "LRS Data Stored", "1 GB/Month", 10d));
             double gbHours = Utils.Conversions.GBMonthsToGBHours(10d);
             double expected = gbHours / 1000 * focusStorage.ssd_gb_coefficient * 3;
-            assertEquals(expected, (Double) enriched.get(ENERGY_USED), 0.0001);
+            assertEquals(expected, (Double) enriched.get(ENERGY_USED), 1e-12);
+            assertEquals(gbHours * focusStorage.ssd_embodied_g_per_gb_hour * 3,
+                    (Double) enriched.get(EMBODIED_EMISSIONS), 1e-12);
         }
 
         @Test
         void processRowWithoutQuantity() {
             Map<Column, Object> enriched = enrich(row("Storage", "Tables", "LRS Data Stored", "1 GB/Month", null));
             assertFalse(enriched.containsKey(ENERGY_USED));
+            assertFalse(enriched.containsKey(EMBODIED_EMISSIONS));
         }
 
         private Row row(String meterCategory, String meterSubCategory, String meterName, String unit, Double quantity) {


### PR DESCRIPTION
Closes #102.

Adds `embodied_emissions_co2eq_g` to the Storage modules for both AWS and Azure, amortised over a five year service life. Until now embodied emissions were only estimated for compute instances and LLM inference, following CCF, which [models them for compute usage types only](https://www.cloudcarbonfootprint.org/docs/embodied-emissions).

## Values

| | HDD | SSD |
|---|---|---|
| basis | 30 kg CO2eq per drive, divided by an assumed 15 TB | 0.055 kg CO2eq per GB |
| life | 43800 h | 43800 h |
| coefficient | 4.566e-5 g/GB-hour | 1.256e-3 g/GB-hour |
| works out at | 0.40 kg CO2eq per TB-year | 11 kg CO2eq per TB-year |

The two media are modelled on different bases because they behave differently. A hard drive costs roughly the same to manufacture whatever its capacity, since the platters, motor, actuator, casing and PCB are near-fixed for a 3.5" unit and areal density does the work. An SSD's die area scales with capacity.

## Why 30 kg per drive

Four independent sources land within 8 % of each other across a 40x span of drive capacities, which is itself the evidence for treating HDD embodied carbon as capacity independent:

| source | stated as | capacity behind it | per drive |
|---|---|---|---|
| [Boavizta](https://doc.api.boavizta.org/Explanations/components/hdd/) / [Umweltbundesamt 2021](https://www.umweltbundesamt.de/sites/default/files/medien/5750/publikationen/2021-06-17_texte_94-2021_green-cloud-computing.pdf) | 31.11 kg per unit | modelled capacity-independent | 31.1 kg |
| Seagate Exos X22 LCA, via [Tailpipe](https://tailpipe.ai/methodology/embodied-emissions-methodology-manufacture/) | 0.0013 kg/GB | 22 TB | 28.7 kg |
| [Seagate](https://www.seagate.com/blog/hard-drives-the-key-to-data-center-sustainability/) | 0.27 kg/TB-year | ~22.6 TB | ~30.5 kg |
| [Tannu &amp; Nair 2023](https://arxiv.org/pdf/2207.10793), 24 vendor LCAs | SEF 0.02 kg/GB | sample spans 512 GB to 6 TB | ~30 kg at their mean |

If manufacturing carbon tracked bytes, those would differ by 40x rather than 8 %.

Note that the Tannu &amp; Nair rate cannot be applied per GB to current hardware: 0.02 kg/GB encodes the drive sizes of a pre-2023 LCA corpus and overstates per-byte embodied carbon by about an order of magnitude. Their Table 1 also gives 1 TB CAPEX as 20 kg at five years, not the 40 kg quoted second-hand in #102, which is the ten year column and includes a replacement drive.

For SSD, [Boavizta's die-area formula](https://doc.api.boavizta.org/Explanations/components/ssd/) (0.052 kg/GB) and the 2025 [Embodied Carbon Footprint of 3D NAND Memories](https://hal.science/hal-05015578v1/document) study (0.056) agree within 8 %. Tannu &amp; Nair's 0.16 kg/GB is roughly 3x higher because 3D NAND layer scaling has cut per-GB manufacturing carbon since their corpus closed.

The assumed 15 TB drive is the installed-fleet average implied by [Backblaze's 2025 Drive Stats](https://www.backblaze.com/blog/backblaze-drive-stats-for-2025/) (341,664 drives: 25.13 % at 0 to 12 TB, 52.06 % at 14 to 16 TB, 22.81 % at 20 TB+). That is the right basis for bytes sitting on hardware bought over several years; current nearline shipments average nearer 22 TB, which would give 0.27 kg per TB-year instead of 0.40.

All four inputs are configuration keys (`hdd_embodied_kg_per_drive`, `hdd_capacity_gb`, `ssd_embodied_kg_per_gb`, `storage_lifetime_hours`), wired into the four default configs.

## Notes

The replication factor applies to embodied as it does to energy: the same bytes occupy that many times more physical drives.

On Azure, `hdd_capacity_gb` describes the physical drive, not a Managed Disk SKU. The provisioned size of a P10 or S4 volume says nothing about the drive underneath it, so the capacities in `MANAGED_DISKS` must not be substituted here. Flagged in the javadoc so it does not get "fixed" later.

One consequence worth knowing before merging: SSD-backed storage becomes embodied-dominated. A gp3 volume comes out at roughly 11 kg CO2eq per TB-year embodied against about 4 kg operational, so EBS lines shift materially in any total-emissions ranking.

## Incidentally

The `AmazonDocDB` case in the AWS `provideArgsWithType` was flagged `isSSD=false` although `AmazonDocDB` is in `SSD_SERVICES`. The energy assertion never caught it because its tolerance was wider than the gap between the two coefficients. Flag corrected and the tolerances tightened from 1e-4 to 1e-12 on both providers.

The numeric parameter reader moved to `Utils.doubleParam` now that both modules need it.

## Still stale

The sample query output in `docs/src/tutorial/results.md` shows `NULL` embodied for the S3 and EBS rows. Those will be populated after this change, but the table comes from a real run rather than a bundled dataset, and the `AmazonECS / FargateTask` row cannot be derived arithmetically because its energy comes from Serverless while its embodied would come from the Fargate ephemeral-storage rows grouped under the same operation. Worth regenerating separately.
