### PR TITLE
Cover DocumentDB Elastic, Amazon MQ and ElastiCache

### DIFF
--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -127,8 +127,13 @@ which map one-to-one to the CUR transfer types.
 
 ### Serverless
 
-Estimates the energy for the memory and vCPU usage of serverless services like Fargate or
-EMR. The default coefficients are taken from the [Tailpipe methodology](https://tailpipe.ai/methodology/serverless-explained/).
+Estimates the energy for the memory and vCPU usage of serverless services like Fargate,
+EMR Serverless or DocumentDB Elastic, which bill compute in vCPU-hours and GB-hours rather than
+by instance type. The default coefficients are taken from the [Tailpipe methodology](https://tailpipe.ai/methodology/serverless-explained/).
+
+DocumentDB Elastic clusters bill their compute as `ElasticCPUUsage` in vCPU-hours; the storage and
+backup lines of the same clusters are covered by [Storage](#storage) instead. AWS does not document
+the underlying hardware, so the x86 coefficient is applied.
 
 | | |
 |---|---|
@@ -168,12 +173,24 @@ draw is scaled accordingly.
 ### Compute — Boavizta
 
 Estimates the [final energy](https://www.eea.europa.eu/en/analysis/indicators/primary-and-final-energy-consumption)
-used for computation (e.g. EC2, OpenSearch, RDS on AWS; virtual machines on Azure), as well
-as the related embodied emissions and abiotic resource depletion, using the
+used for computation (e.g. EC2, OpenSearch, RDS, Amazon MQ, ElastiCache on AWS; virtual machines on
+Azure), as well as the related embodied emissions and abiotic resource depletion, using the
 [BoaviztAPI](https://doc.api.boavizta.org/).
 
 In a CUR, the instance type is read from `product_instance_type`; a FOCUS report does not carry
 it, so it is parsed from the `SkuMeter` column instead (e.g. `EUW2-BoxUsage:t3.xlarge`).
+
+Several managed services report their instance shape behind a service-specific prefix, which is
+removed before the lookup: `db.` for RDS, `mq.` for Amazon MQ, `cache.` for ElastiCache, and the
+`.search` suffix for OpenSearch. The two formats do not always agree on this, so both are
+normalised: `product_instance_type` already reads `m5.large` for an Amazon MQ broker, while the
+matching `SkuMeter` still reads `mq.m5.large`.
+
+Amazon MQ is also the one service here that does not bill per instance. A clustered deployment is
+charged one *cluster*-hour whatever its size, so a three-node RabbitMQ cluster running for an hour
+appears as a single unit of `USE1-RabbitMQ-3-InstanceUsage:mq.m5.large`. The node count is read
+back from the usage type and applied to both the energy and the embodied impacts; usage types
+carrying no such marker are treated as a single instance, and `Multi-AZ` as two.
 
 Each provider has two variants:
 

--- a/src/main/java/com/digitalpebble/spruce/modules/aws/Serverless.java
+++ b/src/main/java/com/digitalpebble/spruce/modules/aws/Serverless.java
@@ -19,7 +19,7 @@ import static com.digitalpebble.spruce.SpruceColumn.*;
 
 /**
  *  Estimates the energy usage for CPU and memory of serverless services
- *  such as Fargate or EMR
+ *  such as Fargate, EMR Serverless or DocumentDB Elastic
  *  Based on the TailPipe methodology
  *  https://tailpipe.ai/methodology/serverless-explained/
  *  as of 08/10/2025
@@ -135,6 +135,14 @@ public class Serverless implements EnrichmentModule {
                 enrichedValues.put(ENERGY_USED, energy);
                 return;
             }
+        }
+        // DocumentDB Elastic bills compute directly in vCPU-hours. The storage and backup lines of
+        // the same clusters are handled by the Storage module. AWS does not say what the underlying
+        // hardware is, so the x86 coefficient is used.
+        else if (usage_type.endsWith("ElasticCPUUsage")) {
+            double amount_vcpu = usageAmount.getDouble(row);
+            double energy = amount_vcpu * x86_cpu_coefficient_kwh;
+            enrichedValues.put(ENERGY_USED, energy);
         }
     }
 }

--- a/src/main/java/com/digitalpebble/spruce/modules/boavizta/aws/AbstractBoaviztaAws.java
+++ b/src/main/java/com/digitalpebble/spruce/modules/boavizta/aws/AbstractBoaviztaAws.java
@@ -14,14 +14,16 @@ import org.apache.spark.sql.Row;
 
 import static com.digitalpebble.spruce.CURColumn.LINE_ITEM_OPERATION;
 import static com.digitalpebble.spruce.CURColumn.LINE_ITEM_PRODUCT_CODE;
+import static com.digitalpebble.spruce.CURColumn.LINE_ITEM_USAGE_TYPE;
 import static com.digitalpebble.spruce.CURColumn.PRODUCT_INSTANCE_TYPE;
 import static com.digitalpebble.spruce.CURColumn.PRODUCT_SERVICE_CODE;
 import static com.digitalpebble.spruce.CURColumn.USAGE_AMOUNT;
 
 /**
  * AWS-specific extraction of the Boavizta instance type from a CUR or FOCUS row. Recognises EC2,
- * OpenSearch (ESDomain) and RDS instance lines and normalises the instance type the way the
- * Boavizta data expects it (stripping the {@code .search} suffix and the {@code db.} prefix).
+ * OpenSearch (ESDomain), RDS, Amazon MQ and ElastiCache instance lines and normalises the instance
+ * type the way the Boavizta data expects it (stripping the {@code .search} suffix and the
+ * {@code db.}, {@code mq.} and {@code cache.} prefixes).
  *
  * <p>FOCUS reports carry no {@code product_instance_type}; the instance type is recovered from
  * the {@code SkuMeter} column instead, whose values are the CUR usage types (e.g.
@@ -29,12 +31,22 @@ import static com.digitalpebble.spruce.CURColumn.USAGE_AMOUNT;
  * instance type is the part after the colon. {@code x_ServiceCode} carries the CUR
  * {@code line_item_product_code}, which for instance lines matches {@code product_servicecode}.
  *
+ * <p>Most services bill one instance-hour per running instance, but Amazon MQ bills one
+ * <em>cluster</em>-hour whatever the deployment size: a three-node RabbitMQ cluster running for an
+ * hour is a single unit of {@code USE1-RabbitMQ-3-InstanceUsage:mq.m5.large}, described in the CUR
+ * as "3-node cluster mq.m5.large hour". The usage amount is scaled by the node count read back
+ * from the usage type, otherwise such clusters would be counted as a single broker.
+ *
  * <p>Subclasses only need to plug in the lookup variant via {@link #lookupImpacts(String)}.
  */
 abstract class AbstractBoaviztaAws extends AbstractBoaviztaModule {
 
+    private static final String INSTANCE_USAGE = "-InstanceUsage";
+    private static final String MULTI_AZ = "-Multi-AZ";
+
     private static final Column[] COLUMNS_NEEDED = new Column[]{
-            PRODUCT_INSTANCE_TYPE, PRODUCT_SERVICE_CODE, LINE_ITEM_OPERATION, LINE_ITEM_PRODUCT_CODE, USAGE_AMOUNT
+            PRODUCT_INSTANCE_TYPE, PRODUCT_SERVICE_CODE, LINE_ITEM_OPERATION, LINE_ITEM_PRODUCT_CODE, USAGE_AMOUNT,
+            LINE_ITEM_USAGE_TYPE
     };
 
     private static final Column[] COLUMNS_NEEDED_FOCUS = new Column[]{
@@ -46,6 +58,7 @@ abstract class AbstractBoaviztaAws extends AbstractBoaviztaModule {
     private RowColumn serviceCode = PRODUCT_SERVICE_CODE;
     private RowColumn productCode = LINE_ITEM_PRODUCT_CODE;
     private RowColumn usageAmount = USAGE_AMOUNT;
+    private RowColumn usageType = LINE_ITEM_USAGE_TYPE;
 
     AbstractBoaviztaAws() {
         // The class is AWS-specific by definition; default the provider so callers that bypass
@@ -61,11 +74,13 @@ abstract class AbstractBoaviztaAws extends AbstractBoaviztaModule {
             serviceCode = AWSFOCUSColumn.X_SERVICE_CODE;
             productCode = AWSFOCUSColumn.X_SERVICE_CODE;
             usageAmount = FOCUSColumn.CONSUMED_QUANTITY;
+            usageType = FOCUSColumn.SKU_METER;
         } else {
             operation = LINE_ITEM_OPERATION;
             serviceCode = PRODUCT_SERVICE_CODE;
             productCode = LINE_ITEM_PRODUCT_CODE;
             usageAmount = USAGE_AMOUNT;
+            usageType = LINE_ITEM_USAGE_TYPE;
         }
     }
 
@@ -76,7 +91,36 @@ abstract class AbstractBoaviztaAws extends AbstractBoaviztaModule {
 
     @Override
     protected final double getUsageAmount(Row row) {
-        return usageAmount.getDouble(row);
+        return usageAmount.getDouble(row) * nodeCount(this.usageType.getString(row));
+    }
+
+    /**
+     * Number of instances covered by one billed unit of {@code usageType}. Amazon MQ encodes the
+     * deployment size in the usage type: {@code RabbitMQ-3-InstanceUsage} is a three-node cluster
+     * and {@code ActiveMQ-Multi-AZ-InstanceUsage} an active/standby pair, while a single-broker
+     * deployment carries no marker at all. Everything else bills per instance, so returns 1.
+     */
+    static int nodeCount(String usageType) {
+        if (usageType == null) {
+            return 1;
+        }
+        int marker = usageType.indexOf(INSTANCE_USAGE);
+        if (marker < 0) {
+            return 1;
+        }
+        // a digit run immediately before "-InstanceUsage" is the node count
+        int end = marker;
+        int start = end;
+        while (start > 0 && Character.isDigit(usageType.charAt(start - 1))) {
+            start--;
+        }
+        if (start < end && start > 0 && usageType.charAt(start - 1) == '-') {
+            return Integer.parseInt(usageType.substring(start, end));
+        }
+        if (usageType.regionMatches(true, Math.max(0, marker - MULTI_AZ.length()), MULTI_AZ, 0, MULTI_AZ.length())) {
+            return 2;
+        }
+        return 1;
     }
 
     @Override
@@ -106,11 +150,21 @@ abstract class AbstractBoaviztaAws extends AbstractBoaviztaModule {
             return instanceType;
         }
         if (productCode.equals("AmazonRDS") && operation.startsWith("CreateDBInstance")) {
-            if (instanceType.startsWith("db.")) {
-                return instanceType.substring(3);
-            }
-            return instanceType;
+            return stripPrefix(instanceType, "db.");
+        }
+        // Amazon MQ and ElastiCache report the broker/node shape as an EC2 instance type behind a
+        // service prefix. In a CUR product_instance_type already has it stripped for MQ but not for
+        // ElastiCache; in a FOCUS report both keep it, as the value comes from the usage type.
+        if (productCode.equals("AmazonMQ") && operation.startsWith("CreateBroker")) {
+            return stripPrefix(instanceType, "mq.");
+        }
+        if (productCode.equals("AmazonElastiCache") && operation.startsWith("CreateCacheCluster")) {
+            return stripPrefix(instanceType, "cache.");
         }
         return null;
+    }
+
+    private static String stripPrefix(String instanceType, String prefix) {
+        return instanceType.startsWith(prefix) ? instanceType.substring(prefix.length()) : instanceType;
     }
 }

--- a/src/test/java/com/digitalpebble/spruce/modules/aws/ServerlessTest.java
+++ b/src/test/java/com/digitalpebble/spruce/modules/aws/ServerlessTest.java
@@ -94,6 +94,25 @@ class ServerlessTest {
         assertEquals(expected, enriched.get(ENERGY_USED));
     }
 
+    @Test
+    void processDocumentDBElasticvCPU() {
+        double quantity = 4d;
+        Row row = generateRow("CreateCluster", quantity, "USE1-ElasticCPUUsage");
+        Map<Column, Object> enriched = new HashMap<>();
+        serverless.enrich(row, enriched);
+        double expected = serverless.x86_cpu_coefficient_kwh * quantity;
+        assertEquals(expected, enriched.get(ENERGY_USED));
+    }
+
+    /** The storage and backup lines of the same clusters belong to the Storage module. */
+    @Test
+    void ignoresDocumentDBElasticStorage() {
+        Row row = generateRow("CreateCluster", 10d, "USE1-ElasticStorageUsage");
+        Map<Column, Object> enriched = new HashMap<>();
+        serverless.enrich(row, enriched);
+        assertFalse(enriched.containsKey(ENERGY_USED));
+    }
+
     private Row generateRow(String LINE_ITEM_OPERATION, Object USAGE_AMOUNT, String LINE_ITEM_USAGE_TYPE){
         Object[] values = new Object[] {LINE_ITEM_OPERATION, USAGE_AMOUNT, LINE_ITEM_USAGE_TYPE, null};
         return new GenericRowWithSchema(values, schema);
@@ -139,6 +158,16 @@ class ServerlessTest {
         void processFargatevCPU() {
             double quantity = 4d;
             Object[] values = new Object[]{"FargateTask", quantity, "USE1-Fargate-vCPU-Hours:perCPU", null};
+            Row row = new GenericRowWithSchema(values, focusSchema);
+            Map<Column, Object> enriched = new HashMap<>();
+            focusServerless.enrich(row, enriched);
+            assertEquals(focusServerless.x86_cpu_coefficient_kwh * quantity, enriched.get(ENERGY_USED));
+        }
+
+        @Test
+        void processDocumentDBElasticvCPU() {
+            double quantity = 4d;
+            Object[] values = new Object[]{"CreateCluster", quantity, "USE1-ElasticCPUUsage", null};
             Row row = new GenericRowWithSchema(values, focusSchema);
             Map<Column, Object> enriched = new HashMap<>();
             focusServerless.enrich(row, enriched);

--- a/src/test/java/com/digitalpebble/spruce/modules/boavizta/aws/AbstractBoaviztaAwsTest.java
+++ b/src/test/java/com/digitalpebble/spruce/modules/boavizta/aws/AbstractBoaviztaAwsTest.java
@@ -32,7 +32,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Exercises the shared behaviour that lives in {@link AbstractBoaviztaAws} and its parent
- * {@code AbstractBoaviztaModule}: the AWS CUR extraction paths (EC2 / ESDomain / RDS), the
+ * {@code AbstractBoaviztaModule}: the AWS CUR extraction paths (EC2 / ESDomain / RDS / MQ /
+ * ElastiCache), the
  * declared input/output columns, the unknown-instance-type cache, and the impacts × usage
  * multiplication. Variant-specific behaviour (static CSV vs live API) is covered in
  * {@link BoaviztAPIstaticTest} and {@link BoaviztAPITest}.
@@ -56,7 +57,8 @@ class AbstractBoaviztaAwsTest {
                 CURColumn.PRODUCT_SERVICE_CODE,
                 CURColumn.LINE_ITEM_OPERATION,
                 CURColumn.LINE_ITEM_PRODUCT_CODE,
-                CURColumn.USAGE_AMOUNT
+                CURColumn.USAGE_AMOUNT,
+                CURColumn.LINE_ITEM_USAGE_TYPE
         }, module.columnsNeeded());
     }
 
@@ -100,6 +102,60 @@ class AbstractBoaviztaAwsTest {
         assertNotNull(enriched.get(SpruceColumn.ENERGY_USED));
     }
 
+    /** In a CUR the {@code mq.} prefix is already stripped from {@code product_instance_type}. */
+    @Test
+    void amazonMqCreateBrokerResolvesBrokerInstanceType() {
+        module.impactsByType.put("m5.large", new Impacts(1.0, 2.0, 3.0));
+        Map<Column, Object> enriched = enrich("m5.large", "AmazonMQ", "CreateBroker:0001", "AmazonMQ", 1.0,
+                "USE1-ActiveMQ-InstanceUsage:mq.m5.large");
+
+        assertEquals(1.0, (double) enriched.get(SpruceColumn.ENERGY_USED), 1e-12);
+    }
+
+    /**
+     * A RabbitMQ cluster bills one unit per cluster-hour, so the impacts of a single broker have to
+     * be multiplied by the number of nodes in the deployment.
+     */
+    @Test
+    void amazonMqClusterScalesUsageByNodeCount() {
+        module.impactsByType.put("m5.large", new Impacts(1.0, 2.0, 3.0));
+        Map<Column, Object> enriched = enrich("m5.large", "AmazonMQ", "CreateBroker:0001", "AmazonMQ", 10.0,
+                "USE1-RabbitMQ-3-InstanceUsage:mq.m5.large");
+
+        assertEquals(30.0, (double) enriched.get(SpruceColumn.ENERGY_USED), 1e-12);
+        assertEquals(60.0, (double) enriched.get(SpruceColumn.EMBODIED_EMISSIONS), 1e-12);
+        assertEquals(90.0, (double) enriched.get(SpruceColumn.EMBODIED_ADP), 1e-12);
+    }
+
+    @Test
+    void elastiCacheStripsCachePrefixBeforeLookup() {
+        module.impactsByType.put("t3.medium", new Impacts(1.0, 1.0, 1.0));
+        Map<Column, Object> enriched = enrich("cache.t3.medium", "AmazonElastiCache", "CreateCacheCluster:0001",
+                "AmazonElastiCache", 1.0, "NodeUsage:cache.t3.medium");
+
+        assertNotNull(enriched.get(SpruceColumn.ENERGY_USED));
+    }
+
+    @ParameterizedTest
+    @MethodSource("nodeCounts")
+    void nodeCountReadFromUsageType(String usageType, int expected) {
+        assertEquals(expected, AbstractBoaviztaAws.nodeCount(usageType));
+    }
+
+    static Stream<Arguments> nodeCounts() {
+        return Stream.of(
+                Arguments.of("USE1-RabbitMQ-3-InstanceUsage:mq.m5.large", 3),
+                Arguments.of("USE1-ActiveMQ-Multi-AZ-InstanceUsage:mq.m5.large", 2),
+                Arguments.of("USE1-ActiveMQ-InstanceUsage:mq.m5.large", 1),
+                Arguments.of("USE1-RabbitMQ-InstanceUsage:mq.m7g.large", 1),
+                // meters without the marker at all bill per instance
+                Arguments.of("EUW2-BoxUsage:t3.xlarge", 1),
+                Arguments.of("InstanceUsage:db.t3.micro", 1),
+                Arguments.of("NodeUsage:cache.t3.medium", 1),
+                Arguments.of(null, 1)
+        );
+    }
+
     @Test
     void unknownInstanceTypeIsCachedAndNotRetried() {
         Map<Column, Object> first = enrich("t3.unknown", "AmazonEC2", "RunInstances", "AmazonEC2", 1.0);
@@ -133,14 +189,23 @@ class AbstractBoaviztaAwsTest {
                 // EC2 path requires service code match — different service code skips
                 Arguments.of("t3.micro", "AmazonOther", "RunInstances", "AmazonEC2"),
                 // case-sensitive product code match
-                Arguments.of("t3.micro", "amazonec2", "RunInstances", "amazonec2")
+                Arguments.of("t3.micro", "amazonec2", "RunInstances", "amazonec2"),
+                // MQ and ElastiCache lines that are not broker/node usage
+                Arguments.of("m5.large", "AmazonMQ", "CreateConfiguration", "AmazonMQ"),
+                Arguments.of("cache.t3.medium", "AmazonElastiCache", "CreateSnapshot", "AmazonElastiCache")
         );
     }
 
     private Map<Column, Object> enrich(String instanceType, String serviceCode,
                                         String operation, String productCode, double usage) {
+        return enrich(instanceType, serviceCode, operation, productCode, usage, null);
+    }
+
+    private Map<Column, Object> enrich(String instanceType, String serviceCode,
+                                        String operation, String productCode, double usage,
+                                        String usageType) {
         Object[] values = new Object[]{
-                instanceType, serviceCode, operation, productCode, usage,
+                instanceType, serviceCode, operation, productCode, usage, usageType,
                 null, null, null
         };
         Row row = new GenericRowWithSchema(values, schema);
@@ -196,6 +261,23 @@ class AbstractBoaviztaAwsTest {
         void rdsStripsDbPrefixBeforeLookup() {
             focusModule.impactsByType.put("t3.micro", new Impacts(1.0, 1.0, 1.0));
             Map<Column, Object> enriched = enrich("InstanceUsage:db.t3.micro", "AmazonRDS", "CreateDBInstance", 1.0);
+            assertNotNull(enriched.get(SpruceColumn.ENERGY_USED));
+        }
+
+        /** Unlike the CUR, the SkuMeter keeps the {@code mq.} prefix, so it has to be stripped. */
+        @Test
+        void amazonMqStripsMqPrefixAndScalesByNodeCount() {
+            focusModule.impactsByType.put("m5.large", new Impacts(1.0, 1.0, 1.0));
+            Map<Column, Object> enriched = enrich("USE1-RabbitMQ-3-InstanceUsage:mq.m5.large", "AmazonMQ",
+                    "CreateBroker:0001", 10.0);
+            assertEquals(30.0, (double) enriched.get(SpruceColumn.ENERGY_USED), 1e-12);
+        }
+
+        @Test
+        void elastiCacheStripsCachePrefixBeforeLookup() {
+            focusModule.impactsByType.put("t3.medium", new Impacts(1.0, 1.0, 1.0));
+            Map<Column, Object> enriched = enrich("NodeUsage:cache.t3.medium", "AmazonElastiCache",
+                    "CreateCacheCluster:0001", 1.0);
             assertNotNull(enriched.get(SpruceColumn.ENERGY_USED));
         }
 


### PR DESCRIPTION
Three services that accounted for a large share of the uncovered spend in AWS CUR reports, all within reach of existing modules.

## DocumentDB Elastic

`ElasticCPUUsage` is billed directly in vCPU-hours, which is exactly what the `Serverless` module already consumes for Fargate and EMR Serverless, so it drops into the same branch structure. The storage and backup lines of those clusters were already handled by `Storage`. AWS does not document the underlying hardware, so the x86 coefficient is applied.

No embodied emissions for this one: the vCPU-hour route has no hardware to amortise.

## Amazon MQ and ElastiCache

Both report their broker/node shape as an EC2 instance type behind a service prefix, so the Boavizta lookup only needed new gates plus prefix stripping (refactored into a shared `stripPrefix` helper that also absorbs the existing `db.` case).

The two report formats disagree on the prefix, so both are normalised:

| | CUR | FOCUS |
|---|---|---|
| Amazon MQ | `product_instance_type` = `m5.large` | `SkuMeter` = `...InstanceUsage:mq.m5.large` |
| ElastiCache | `product_instance_type` = `cache.t3.medium` | `SkuMeter` = `NodeUsage:cache.t3.medium` |

Amazon MQ is also the only service here that does not bill per instance. A clustered deployment is charged one **cluster**-hour whatever its size, so a three-node RabbitMQ cluster running for an hour appears as a single unit of `USE1-RabbitMQ-3-InstanceUsage:mq.m5.large`, described in the CUR as "3-node cluster mq.m5.large hour". Without this, such clusters would be counted as a single broker. `nodeCount()` reads the node count back from the usage type and applies it to energy and embodied impacts alike; `Multi-AZ` counts as two, anything unmarked as one.

This required adding `LINE_ITEM_USAGE_TYPE` to the CUR `columnsNeeded`; FOCUS already had `SkuMeter`.

## Verification

Ran over a real month of CUR data (`BILLING_PERIOD=2026-07`) and diffed against the previously enriched output:

| service | old kWh | new kWh | new embodied kg | old uncovered $ | new uncovered $ |
|---|---|---|---|---|---|
| AmazonDocDB | 16.71 | 56.05 | - | 589.25 | 0 |
| AmazonMQ | 0.08 | 6.28 | 1.161 | 610.15 | 0 |
| AmazonElastiCache | - | 2.27 | 0.231 | 50.59 | 0 |

Coverage for the month goes from 81.47% to 84.90%, with nothing else moving.

The node scaling checks out exactly: `m7g.large` is `0.00277778` kWh in the Boavizta table, and the enriched rows come out at `0.008333` kWh per cluster-hour.

Ran the same month through both formats to confirm the FOCUS path agrees. Energy, emissions and water match to 0.007% (float accumulation over a 12x row-count difference), embodied matches to the cent, and all three services produce identical figures. The only divergence is in the cost columns, entirely Savings Plan related and unchanged by this PR: CUR `SavingsPlanCoveredUsage` lines carry $18,990.30 of unblended cost that the same usage reports as `PricingCategory = Committed` with `BilledCost` 0 in a real FOCUS export.

387 tests pass, with new cases for both formats covering the gates, the prefix stripping and the node-count parsing.